### PR TITLE
Feat/adding apps wildcard -> ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ No modules.
 | [aws_iam_user_policy_attachment.externaldns](https://registry.terraform.io/providers/hashicorp/aws/4.39.0/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.vault_s3](https://registry.terraform.io/providers/hashicorp/aws/4.39.0/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_route53_record.cluster_subdomain_ns_records](https://registry.terraform.io/providers/hashicorp/aws/4.39.0/docs/resources/route53_record) | resource |
+| [aws_route53_record.wildcard_for_apps](https://registry.terraform.io/providers/hashicorp/aws/4.39.0/docs/resources/route53_record) | resource |
 | [aws_route53_zone.clusters](https://registry.terraform.io/providers/hashicorp/aws/4.39.0/docs/resources/route53_zone) | resource |
 | [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/4.39.0/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.primary](https://registry.terraform.io/providers/hashicorp/aws/4.39.0/docs/resources/s3_bucket) | resource |
@@ -75,7 +76,7 @@ No modules.
 | <a name="input_company_key"></a> [company\_key](#input\_company\_key) | The company key | `string` | n/a | yes |
 | <a name="input_domain_to_delegate_from"></a> [domain\_to\_delegate\_from](#input\_domain\_to\_delegate\_from) | The domain name of the domain that all delegation is coming from | `string` | n/a | yes |
 | <a name="input_primary_region"></a> [primary\_region](#input\_primary\_region) | The primary S3 region to create S3 bucket in used for backups. This should be the same region as the one where the cluster is being deployed. | `string` | n/a | yes |
-| <a name="input_this_is_development"></a> [this\_is\_development](#input\_this\_is\_development) | The develoopment cluster environment and data/resources can be destroyed! | `string` | `false` | no |
+| <a name="input_this_is_development"></a> [this\_is\_development](#input\_this\_is\_development) | The development cluster environment and data/resources can be destroyed! | `string` | `false` | no |
 
 ## Outputs
 

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -8,7 +8,7 @@ resource "cloudflare_record" "delegation_ns_record_first" {
   name     = aws_route53_zone.main.name
   value    = aws_route53_zone.main.name_servers[0]
   type     = local.ns_record_type
-  ttl      = local.ns_record_ttl
+  ttl      = local.record_ttl
   proxied  = false
   priority = null
 }

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -19,7 +19,7 @@ resource "cloudflare_record" "delegation_ns_record_second" {
   name     = aws_route53_zone.main.name
   value    = aws_route53_zone.main.name_servers[1]
   type     = local.ns_record_type
-  ttl      = local.ns_record_ttl
+  ttl      = local.record_ttl
   proxied  = false
   priority = null
 }
@@ -29,7 +29,7 @@ resource "cloudflare_record" "delegation_ns_record_third" {
   name     = aws_route53_zone.main.name
   value    = aws_route53_zone.main.name_servers[2]
   type     = local.ns_record_type
-  ttl      = local.ns_record_ttl
+  ttl      = local.record_ttl
   proxied  = false
   priority = null
 }
@@ -39,7 +39,7 @@ resource "cloudflare_record" "delegation_ns_record_fourth" {
   name     = aws_route53_zone.main.name
   value    = aws_route53_zone.main.name_servers[3]
   type     = local.ns_record_type
-  ttl      = local.ns_record_ttl
+  ttl      = local.record_ttl
   proxied  = false
   priority = null
 }

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,16 @@ resource "aws_route53_zone" "main" {
   name     = "${local.company_key}.${local.domain_to_delegate_from}"
 }
 
+resource "aws_route53_record" "wildcard_for_apps" {
+  provider = aws.clientaccount
+  for_each = aws_route53_zone.clusters
+  zone_id  = each.value.zone_id
+  name     = "*.apps.${each.value.name}"
+  type     = "CNAME"
+  ttl      = local.record_ttl
+  record   = "ingress.${each.value.name}"
+}
+
 resource "aws_route53_zone" "clusters" {
   provider = aws.clientaccount
   for_each = toset(var.cluster_environments)
@@ -19,7 +29,7 @@ resource "aws_route53_record" "cluster_subdomain_ns_records" {
   zone_id  = aws_route53_zone.main.zone_id
   name     = each.value.name
   type     = local.ns_record_type
-  ttl      = local.ns_record_ttl
+  ttl      = local.record_ttl
   records  = aws_route53_zone.clusters[each.key].name_servers
 }
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ resource "aws_route53_record" "wildcard_for_apps" {
   name     = "*.apps.${each.value.name}"
   type     = "CNAME"
   ttl      = local.record_ttl
-  record   = "ingress.${each.value.name}"
+  records  = ["ingress.${each.value.name}"]
 }
 
 resource "aws_route53_zone" "clusters" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "backup_region" {
 locals {
   domain_to_delegate_from = var.domain_to_delegate_from
   company_key             = var.company_key
-  ns_record_ttl           = "60"
+  record_ttl              = "60"
   ns_record_type          = "NS"
   bucket_name             = "glueops-tenant-${local.company_key}"
 }


### PR DESCRIPTION
feat: adding *.apps.<clustername>.<companykey>.glueophosted.TLD so that apps coming online will quickly resolve to `ingress.<clustername>.<companykey>.glueophosted.TLD`. The `ingress.<clustername>.<companykey>.glueophosted.TLD.` will resolve to the external load balancer and will be defined by `external-dns` from the cluster itself as it comes online and deploys it's external-load balancer