### PR TITLE
feat: updating argocd from v2.7.6 -> v2.7.7. ALso updating to the lat…

### DIFF
--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -35,9 +35,9 @@ data "local_file" "readme" {
 
 locals {
   codespace_version         = "v0.26.0"
-  argocd_crd_version        = "v2.7.6"
-  argocd_helm_chart_version = "5.36.14"
-  glueops_platform_version  = "0.19.1"
+  argocd_crd_version        = "v2.7.7"
+  argocd_helm_chart_version = "5.38.0"
+  glueops_platform_version  = "0.19.1" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.1.5"
 }
 


### PR DESCRIPTION
…est helm chart for argocd that uses the latest version of dexIDP