### PR TITLE
chore(argocd): update argocd crd/app v2.8.2 -> v2.8.3, argocd helm ch…

### DIFF
--- a/generate-tenant-readmes.tf
+++ b/generate-tenant-readmes.tf
@@ -1,5 +1,5 @@
 locals {
-  argocd_app_version = "v2.8.2"
+  argocd_app_version = "v2.8.3"
 
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -41,7 +41,7 @@ data "local_file" "readme" {
 locals {
   codespace_version         = "v0.29.0"
   argocd_crd_version        = var.argocd_app_version
-  argocd_helm_chart_version = "5.45.1"
+  argocd_helm_chart_version = "5.45.4"
   glueops_platform_version  = "v0.32.0" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.4.2"
 }


### PR DESCRIPTION
…art 5.45.1 -> 5.45.4

not upgrading to helm chart 5.45.5 due to warnings in helm from incorrect value tyes