### PR TITLE
chore(codespace_version): v0.31.0 -> v0.31.1

### DIFF
--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -39,7 +39,7 @@ data "local_file" "readme" {
 }
 
 locals {
-  codespace_version         = "v0.31.0"
+  codespace_version         = "v0.31.1"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.45.4"
   glueops_platform_version  = "v0.33.0" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf


### PR DESCRIPTION
Why not just keep it on the release branch?