### PR TITLE
Release/0.35.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_argocd_helm_values"></a> [argocd\_helm\_values](#module\_argocd\_helm\_values) | git::https://github.com/GlueOps/docs-argocd.git | v0.8.0 |
+| <a name="module_argocd_helm_values"></a> [argocd\_helm\_values](#module\_argocd\_helm\_values) | git::https://github.com/GlueOps/docs-argocd.git | v0.9.0 |
 | <a name="module_captain_repository"></a> [captain\_repository](#module\_captain\_repository) | ./modules/github-captain-repository/0.1.0 | n/a |
 | <a name="module_captain_repository_files"></a> [captain\_repository\_files](#module\_captain\_repository\_files) | ./modules/github-captain-repository-files/0.1.0 | n/a |
 | <a name="module_common_s3"></a> [common\_s3](#module\_common\_s3) | ./modules/multy-s3-bucket/0.1.0 | n/a |
 | <a name="module_dnssec_key"></a> [dnssec\_key](#module\_dnssec\_key) | git::https://github.com/GlueOps/terraform-module-cloud-aws-dnssec-kms-key.git | v0.1.0 |
-| <a name="module_glueops_platform_helm_values"></a> [glueops\_platform\_helm\_values](#module\_glueops\_platform\_helm\_values) | git::https://github.com/GlueOps/platform-helm-chart-platform.git | v0.35.0-rc6 |
+| <a name="module_glueops_platform_helm_values"></a> [glueops\_platform\_helm\_values](#module\_glueops\_platform\_helm\_values) | git::https://github.com/GlueOps/platform-helm-chart-platform.git | v0.35.0-rc7 |
 | <a name="module_loki_s3"></a> [loki\_s3](#module\_loki\_s3) | ./modules/multy-s3-bucket/0.1.0 | n/a |
 | <a name="module_opsgenie_teams"></a> [opsgenie\_teams](#module\_opsgenie\_teams) | ./modules/opsgenie/0.1.0 | n/a |
 | <a name="module_tenant_readmes"></a> [tenant\_readmes](#module\_tenant\_readmes) | ./modules/tenant-readme/0.1.0 | n/a |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ No requirements.
 | <a name="module_captain_repository_files"></a> [captain\_repository\_files](#module\_captain\_repository\_files) | ./modules/github-captain-repository-files/0.1.0 | n/a |
 | <a name="module_common_s3"></a> [common\_s3](#module\_common\_s3) | ./modules/multy-s3-bucket/0.1.0 | n/a |
 | <a name="module_dnssec_key"></a> [dnssec\_key](#module\_dnssec\_key) | git::https://github.com/GlueOps/terraform-module-cloud-aws-dnssec-kms-key.git | v0.1.0 |
-| <a name="module_glueops_platform_helm_values"></a> [glueops\_platform\_helm\_values](#module\_glueops\_platform\_helm\_values) | git::https://github.com/GlueOps/platform-helm-chart-platform.git | v0.35.0-rc7 |
+| <a name="module_glueops_platform_helm_values"></a> [glueops\_platform\_helm\_values](#module\_glueops\_platform\_helm\_values) | git::https://github.com/GlueOps/platform-helm-chart-platform.git | v0.35.0 |
 | <a name="module_loki_s3"></a> [loki\_s3](#module\_loki\_s3) | ./modules/multy-s3-bucket/0.1.0 | n/a |
 | <a name="module_opsgenie_teams"></a> [opsgenie\_teams](#module\_opsgenie\_teams) | ./modules/opsgenie/0.1.0 | n/a |
 | <a name="module_tenant_readmes"></a> [tenant\_readmes](#module\_tenant\_readmes) | ./modules/tenant-readme/0.1.0 | n/a |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ No requirements.
 | <a name="module_captain_repository_files"></a> [captain\_repository\_files](#module\_captain\_repository\_files) | ./modules/github-captain-repository-files/0.1.0 | n/a |
 | <a name="module_common_s3"></a> [common\_s3](#module\_common\_s3) | ./modules/multy-s3-bucket/0.1.0 | n/a |
 | <a name="module_dnssec_key"></a> [dnssec\_key](#module\_dnssec\_key) | git::https://github.com/GlueOps/terraform-module-cloud-aws-dnssec-kms-key.git | v0.1.0 |
-| <a name="module_glueops_platform_helm_values"></a> [glueops\_platform\_helm\_values](#module\_glueops\_platform\_helm\_values) | git::https://github.com/GlueOps/platform-helm-chart-platform.git | v0.35.0-rc3 |
+| <a name="module_glueops_platform_helm_values"></a> [glueops\_platform\_helm\_values](#module\_glueops\_platform\_helm\_values) | git::https://github.com/GlueOps/platform-helm-chart-platform.git | v0.35.0-rc6 |
 | <a name="module_loki_s3"></a> [loki\_s3](#module\_loki\_s3) | ./modules/multy-s3-bucket/0.1.0 | n/a |
 | <a name="module_opsgenie_teams"></a> [opsgenie\_teams](#module\_opsgenie\_teams) | ./modules/opsgenie/0.1.0 | n/a |
 | <a name="module_tenant_readmes"></a> [tenant\_readmes](#module\_tenant\_readmes) | ./modules/tenant-readme/0.1.0 | n/a |

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_argocd_helm_values"></a> [argocd\_helm\_values](#module\_argocd\_helm\_values) | git::https://github.com/GlueOps/docs-argocd.git | v0.7.0 |
+| <a name="module_argocd_helm_values"></a> [argocd\_helm\_values](#module\_argocd\_helm\_values) | git::https://github.com/GlueOps/docs-argocd.git | v0.8.0 |
 | <a name="module_captain_repository"></a> [captain\_repository](#module\_captain\_repository) | ./modules/github-captain-repository/0.1.0 | n/a |
 | <a name="module_captain_repository_files"></a> [captain\_repository\_files](#module\_captain\_repository\_files) | ./modules/github-captain-repository-files/0.1.0 | n/a |
 | <a name="module_common_s3"></a> [common\_s3](#module\_common\_s3) | ./modules/multy-s3-bucket/0.1.0 | n/a |
 | <a name="module_dnssec_key"></a> [dnssec\_key](#module\_dnssec\_key) | git::https://github.com/GlueOps/terraform-module-cloud-aws-dnssec-kms-key.git | v0.1.0 |
-| <a name="module_glueops_platform_helm_values"></a> [glueops\_platform\_helm\_values](#module\_glueops\_platform\_helm\_values) | git::https://github.com/GlueOps/platform-helm-chart-platform.git | v0.34.0 |
+| <a name="module_glueops_platform_helm_values"></a> [glueops\_platform\_helm\_values](#module\_glueops\_platform\_helm\_values) | git::https://github.com/GlueOps/platform-helm-chart-platform.git | v0.35.0-rc3 |
 | <a name="module_loki_s3"></a> [loki\_s3](#module\_loki\_s3) | ./modules/multy-s3-bucket/0.1.0 | n/a |
 | <a name="module_opsgenie_teams"></a> [opsgenie\_teams](#module\_opsgenie\_teams) | ./modules/opsgenie/0.1.0 | n/a |
 | <a name="module_tenant_readmes"></a> [tenant\_readmes](#module\_tenant\_readmes) | ./modules/tenant-readme/0.1.0 | n/a |

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc2"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc3"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development
@@ -97,7 +97,7 @@ resource "aws_s3_object" "platform_helm_values" {
 
 module "argocd_helm_values" {
   for_each             = local.environment_map
-  source               = "git::https://github.com/GlueOps/docs-argocd.git?ref=v0.7.0"
+  source               = "git::https://github.com/GlueOps/docs-argocd.git?ref=v0.8.0"
   tenant_key           = var.tenant_key
   cluster_environment  = each.value.environment_name
   client_secret        = random_password.dex_argocd_client_secret[each.value.environment_name].result

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc6"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc7"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development
@@ -97,7 +97,7 @@ resource "aws_s3_object" "platform_helm_values" {
 
 module "argocd_helm_values" {
   for_each             = local.environment_map
-  source               = "git::https://github.com/GlueOps/docs-argocd.git?ref=v0.8.0"
+  source               = "git::https://github.com/GlueOps/docs-argocd.git?ref=v0.9.0"
   tenant_key           = var.tenant_key
   cluster_environment  = each.value.environment_name
   client_secret        = random_password.dex_argocd_client_secret[each.value.environment_name].result

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc1"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc2"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc5"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc6"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc9"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc10"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc3"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=0.35.0-rc4"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.34.0"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc1"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc11"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=0.35.0-rc4"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc5"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc10"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc11"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -40,7 +40,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc7"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.35.0-rc9"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development

--- a/generate-tenant-readmes.tf
+++ b/generate-tenant-readmes.tf
@@ -1,5 +1,5 @@
 locals {
-  argocd_app_version = "v2.8.3"
+  argocd_app_version = "v2.8.6"
 
 }
 

--- a/modules/opsgenie/0.1.0/heartbeat.tf
+++ b/modules/opsgenie/0.1.0/heartbeat.tf
@@ -3,7 +3,7 @@ resource "opsgenie_heartbeat" "captain" {
   name           = "${each.value}.${var.domain}"
   description    = "${each.value}.${var.domain}"
   interval_unit  = "minutes"
-  interval       = 2
+  interval       = 3
   enabled        = true
   alert_priority = "P1"
   alert_message  = "Heartbeat Expired: ${each.value}.${var.domain}"

--- a/modules/opsgenie/0.1.0/heartbeat.tf
+++ b/modules/opsgenie/0.1.0/heartbeat.tf
@@ -1,10 +1,11 @@
 resource "opsgenie_heartbeat" "captain" {
-  for_each      = local.cluster_environments_set
-  name          = "${each.value}.${var.domain}"
-  description   = "${each.value}.${var.domain}"
-  interval_unit = "minutes"
-  interval      = 2
-  enabled       = true
-  alert_message = "Heartbeat Expired: ${each.value}.${var.domain}"
-  owner_team_id = opsgenie_team.teams[each.key].id
+  for_each       = local.cluster_environments_set
+  name           = "${each.value}.${var.domain}"
+  description    = "${each.value}.${var.domain}"
+  interval_unit  = "minutes"
+  interval       = 2
+  enabled        = true
+  alert_priority = "P1"
+  alert_message  = "Heartbeat Expired: ${each.value}.${var.domain}"
+  owner_team_id  = opsgenie_team.teams[each.key].id
 }

--- a/modules/opsgenie/0.1.0/heartbeat.tf
+++ b/modules/opsgenie/0.1.0/heartbeat.tf
@@ -1,0 +1,10 @@
+resource "opsgenie_heartbeat" "captain" {
+  for_each      = local.cluster_environments_set
+  name          = "${each.value}.${var.domain}"
+  description   = "${each.value}.${var.domain}"
+  interval_unit = "minutes"
+  interval      = 2
+  enabled       = true
+  alert_message = "Heartbeat Expired: ${each.value}.${var.domain}"
+  owner_team_id = opsgenie_team.teams[each.key].id
+}

--- a/modules/opsgenie/0.1.0/variables.tf
+++ b/modules/opsgenie/0.1.0/variables.tf
@@ -12,3 +12,9 @@ variable "cluster_environments" {
   description = "List of cluster environment names"
   type        = list(string)
 }
+
+
+variable "domain" {
+  description = "glueops delegation domain"
+  type        = string
+}

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -39,7 +39,7 @@ data "local_file" "readme" {
 }
 
 locals {
-  codespace_version         = "v0.31.3"
+  codespace_version         = "v0.31.4"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.50.1"
   glueops_platform_version  = "v0.35.0-rc9" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -42,7 +42,7 @@ locals {
   codespace_version         = "v0.31.1"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.45.4"
-  glueops_platform_version  = "v0.35.0-rc2" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.35.0-rc3" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -42,7 +42,7 @@ locals {
   codespace_version         = "v0.31.1"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.45.4"
-  glueops_platform_version  = "v0.34.0" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.35.0-rc1" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -39,10 +39,10 @@ data "local_file" "readme" {
 }
 
 locals {
-  codespace_version         = "v0.31.2"
+  codespace_version         = "v0.31.3"
   argocd_crd_version        = var.argocd_app_version
-  argocd_helm_chart_version = "5.50.0"
-  glueops_platform_version  = "v0.35.0-rc6" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  argocd_helm_chart_version = "5.50.1"
+  glueops_platform_version  = "v0.35.0-rc7" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -42,7 +42,7 @@ locals {
   codespace_version         = "v0.31.3"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.50.1"
-  glueops_platform_version  = "v0.35.0-rc7" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.35.0-rc9" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -39,10 +39,10 @@ data "local_file" "readme" {
 }
 
 locals {
-  codespace_version         = "v0.31.1"
+  codespace_version         = "v0.31.2"
   argocd_crd_version        = var.argocd_app_version
-  argocd_helm_chart_version = "5.45.4"
-  glueops_platform_version  = "v0.35.0-rc5" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  argocd_helm_chart_version = "5.50.0"
+  glueops_platform_version  = "v0.35.0-rc6" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -42,7 +42,7 @@ locals {
   codespace_version         = "v0.31.4"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.50.1"
-  glueops_platform_version  = "v0.35.0-rc11" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.35.0" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -42,7 +42,7 @@ locals {
   codespace_version         = "v0.31.4"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.50.1"
-  glueops_platform_version  = "v0.35.0-rc9" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.35.0-rc10" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -42,7 +42,7 @@ locals {
   codespace_version         = "v0.31.1"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.45.4"
-  glueops_platform_version  = "v0.35.0-rc1" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.35.0-rc2" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -42,7 +42,7 @@ locals {
   codespace_version         = "v0.31.1"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.45.4"
-  glueops_platform_version  = "v0.35.0-rc3" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "0.35.0-rc4" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -42,7 +42,7 @@ locals {
   codespace_version         = "v0.31.1"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.45.4"
-  glueops_platform_version  = "0.35.0-rc4" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.35.0-rc5" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -42,7 +42,7 @@ locals {
   codespace_version         = "v0.31.4"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.50.1"
-  glueops_platform_version  = "v0.35.0-rc10" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.35.0-rc11" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.5.1"
 }
 

--- a/opsgenie.tf
+++ b/opsgenie.tf
@@ -3,4 +3,5 @@ module "opsgenie_teams" {
   users                = var.opsgenie_emails
   tenant_key           = var.tenant_key
   cluster_environments = local.cluster_environments
+  domain               = aws_route53_zone.main.name
 }


### PR DESCRIPTION
feat: upgrade docs-argocd 0.7.0 -> 0.9.0
- enabling metrics for notifications, argocd server, repo server, applicationset, application controller

feat: upgrade glueops-platform-helm chart v0.34.0 -> v0.35.0
https://github.com/GlueOps/platform-helm-chart-platform/pull/140
feat: upgrade argocd v2.8.3 -> v2.8.6
feat: adding opsgenie heartbeat creation
chore: update codespace version v0.31.1 -> v0.31.4