### PR TITLE
fix: skip bad version 0.8.0 of tools

### DIFF
--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -43,7 +43,7 @@ locals {
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.54.0"
   glueops_platform_version  = "v0.42.0-rc1" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
-  tools_version             = "v0.8.0"
+  tools_version             = "v0.9.0"
 }
 
 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated `tools_version` in the `modules/tenant-readme/0.1.0/readme.tf` file to `v0.9.0` to skip the bad version `0.8.0`.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>readme.tf</strong><dd><code>Update Tools Version in Tenant Readme</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
modules/tenant-readme/0.1.0/readme.tf

- Updated `tools_version` from `v0.8.0` to `v0.9.0`.



</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/159/files#diff-8bec83b21e042797b1941b265a96bf6359cef2e5a7f184288751fd51fd32b736">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

