### PR TITLE
fix: skip bad version 0.8.0 of vault-configuration

### DIFF
--- a/captain-repo.tf
+++ b/captain-repo.tf
@@ -41,7 +41,7 @@ EOT
 
     "terraform/vault/configuration/main.tf" = <<EOT
 module "configure_vault_cluster" {
-    source = "git::https://github.com/GlueOps/terraform-module-kubernetes-hashicorp-vault-configuration.git?ref=v0.8.0"
+    source = "git::https://github.com/GlueOps/terraform-module-kubernetes-hashicorp-vault-configuration.git?ref=v0.9.0"
     oidc_client_secret = "${random_password.dex_vault_client_secret[each.key].result}"
     captain_domain = "${each.value.environment_name}.${aws_route53_zone.main.name}"
     org_team_policy_mappings = [


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated the HashiCorp Vault configuration module in `captain-repo.tf` to use version `v0.9.0` instead of the problematic `v0.8.0`.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>captain-repo.tf</strong><dd><code>Update HashiCorp Vault Configuration Module to v0.9.0</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
captain-repo.tf

<li>Updated the source reference for the <code>configure_vault_cluster</code> module <br>from version <code>v0.8.0</code> to <code>v0.9.0</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/160/files#diff-2b7d680a15af0eec11677fe658a2fb49a865d5d93d27ed080747ce69c64e5c6d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

