### PR TITLE
chore: bump rc10 -> rc11 for glueops-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ No requirements.
 | <a name="module_captain_repository_files"></a> [captain\_repository\_files](#module\_captain\_repository\_files) | ./modules/github-captain-repository-files/0.1.0 | n/a |
 | <a name="module_common_s3"></a> [common\_s3](#module\_common\_s3) | ./modules/multy-s3-bucket/0.1.0 | n/a |
 | <a name="module_dnssec_key"></a> [dnssec\_key](#module\_dnssec\_key) | git::https://github.com/GlueOps/terraform-module-cloud-aws-dnssec-kms-key.git | v0.3.0 |
-| <a name="module_glueops_platform_helm_values"></a> [glueops\_platform\_helm\_values](#module\_glueops\_platform\_helm\_values) | git::https://github.com/GlueOps/platform-helm-chart-platform.git | v0.43.0-rc10 |
+| <a name="module_glueops_platform_helm_values"></a> [glueops\_platform\_helm\_values](#module\_glueops\_platform\_helm\_values) | git::https://github.com/GlueOps/platform-helm-chart-platform.git | v0.43.0-rc11 |
 | <a name="module_loki_s3"></a> [loki\_s3](#module\_loki\_s3) | ./modules/multy-s3-bucket/0.1.0 | n/a |
 | <a name="module_opsgenie_teams"></a> [opsgenie\_teams](#module\_opsgenie\_teams) | ./modules/opsgenie/0.1.0 | n/a |
 | <a name="module_tenant_readmes"></a> [tenant\_readmes](#module\_tenant\_readmes) | ./modules/tenant-readme/0.1.0 | n/a |

--- a/generate-helm-values.tf
+++ b/generate-helm-values.tf
@@ -42,7 +42,7 @@ locals {
 
 module "glueops_platform_helm_values" {
   for_each                                   = local.environment_map
-  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.43.0-rc10"
+  source                                     = "git::https://github.com/GlueOps/platform-helm-chart-platform.git?ref=v0.43.0-rc11"
   captain_repo_b64encoded_private_deploy_key = base64encode(module.captain_repository[each.value.environment_name].private_deploy_key)
   captain_repo_ssh_clone_url                 = module.captain_repository[each.value.environment_name].ssh_clone_url
   this_is_development                        = var.this_is_development

--- a/modules/tenant-readme/0.1.0/readme.tf
+++ b/modules/tenant-readme/0.1.0/readme.tf
@@ -42,7 +42,7 @@ locals {
   codespace_version         = "v0.42.0"
   argocd_crd_version        = var.argocd_app_version
   argocd_helm_chart_version = "5.54.0"
-  glueops_platform_version  = "v0.43.0-rc10" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.43.0-rc11" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.10.0"
 }
 


### PR DESCRIPTION
### **PR Type**
Other, Documentation


___

### **Description**
- Bumped the GlueOps platform Helm chart version from `v0.43.0-rc10` to `v0.43.0-rc11` in `generate-helm-values.tf`.
- Updated the `glueops_platform_version` to `v0.43.0-rc11` in the `modules/tenant-readme/0.1.0/readme.tf` file.
- Modified the `README.md` to reflect the new GlueOps platform Helm values version `v0.43.0-rc11`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-helm-values.tf</strong><dd><code>Bump GlueOps platform Helm chart version in generate-helm-values.tf</code></dd></summary>
<hr>

generate-helm-values.tf
<li>Updated the <code>source</code> URL to use <code>v0.43.0-rc11</code> instead of <code>v0.43.0-rc10</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/181/files#diff-3d8e4dabf2447bf5876727692f04735b56e0ddfc0f0dbbd4d8cf557e419513cc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>readme.tf</strong><dd><code>Update GlueOps platform version in tenant-readme module</code>&nbsp; &nbsp; </dd></summary>
<hr>

modules/tenant-readme/0.1.0/readme.tf
- Updated the `glueops_platform_version` to `v0.43.0-rc11`.



</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/181/files#diff-8bec83b21e042797b1941b265a96bf6359cef2e5a7f184288751fd51fd32b736">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update GlueOps platform Helm values version in README.md</code>&nbsp; </dd></summary>
<hr>

README.md
<li>Updated the <code>glueops_platform_helm_values</code> module version to <br><code>v0.43.0-rc11</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/181/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

