### PR TITLE
fix: use default timezone America/New_York for opsgenie

### DIFF
--- a/modules/opsgenie/0.1.0/main.tf
+++ b/modules/opsgenie/0.1.0/main.tf
@@ -1,7 +1,7 @@
 locals {
   users_set                = toset(var.users)
   cluster_environments_set = toset(var.cluster_environments)
-  time_zone                = "Africa/Monrovia"
+  time_zone                = "America/New_York"
 }
 
 data "opsgenie_user" "users" {


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Updated the default timezone in the Opsgenie configuration from `Africa/Monrovia` to `America/New_York` to ensure correct time settings.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update default timezone to America/New_York in Opsgenie configuration</code></dd></summary>
<hr>

modules/opsgenie/0.1.0/main.tf

<li>Changed the default timezone from <code>Africa/Monrovia</code> to <code>America/New_York</code>.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/281/files#diff-d7a406d8be4d224d46c9c06531f1e565676f777dde258e109a4a862055fbf634">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information