### PR TITLE
feat: updating aws_iam_role for replication to use a hash based name when over 63 characters to avoid character limits

### DIFF
--- a/modules/multy-s3-bucket/0.1.0/s3-replication.tf
+++ b/modules/multy-s3-bucket/0.1.0/s3-replication.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "replication" {
   provider = aws.primaryregion
-  name     = length("tf-role-s3-rplctn-${var.bucket_name}") > 63 ? "tf-s3-repl-${substr(hash("sha256", "tf-role-s3-rplctn-${var.bucket_name}"), 0, 51)}" : "tf-role-s3-rplctn-${var.bucket_name}"
+  name     = length("tf-role-s3-rplctn-${var.bucket_name}") > 63 ? "tf-s3-repl-${substr(sha256("tf-role-s3-rplctn-${var.bucket_name}"), 0, 51)}" : "tf-role-s3-rplctn-${var.bucket_name}"
 
   assume_role_policy = <<POLICY
 {

--- a/modules/multy-s3-bucket/0.1.0/s3-replication.tf
+++ b/modules/multy-s3-bucket/0.1.0/s3-replication.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "replication" {
   provider = aws.primaryregion
-  name     = "tf-role-s3-rplctn-${var.bucket_name}"
+  name     = length("tf-role-s3-rplctn-${var.bucket_name}") > 63 ? "tf-s3-repl-${substr(hash("sha256", "tf-role-s3-rplctn-${var.bucket_name}"), 0, 51)}" : "tf-role-s3-rplctn-${var.bucket_name}"
 
   assume_role_policy = <<POLICY
 {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Update IAM role naming to handle long bucket names

- Use hash-based name if name exceeds 63 characters


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>s3-replication.tf</strong><dd><code>Add hash-based fallback for long IAM role names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/multy-s3-bucket/0.1.0/s3-replication.tf

<li>Modified IAM role name logic to check length<br> <li> Use a hash-based name if name exceeds 63 characters<br> <li> Ensures compliance with AWS IAM role name length limits


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/369/files#diff-448420d24367fe4149a5cd85429d5a8e92624e7dc9759360438ceb045a4aa822">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>