### PR TITLE
fix(chore): bumps up argocd version

### DIFF
--- a/generate-tenant-readmes.tf
+++ b/generate-tenant-readmes.tf
@@ -1,5 +1,5 @@
 locals {
-  argocd_app_version = "v2.14.11"
+  argocd_app_version = "v2.14.12"
 
 }
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Bump ArgoCD application version from v2.14.11 to v2.14.12


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-tenant-readmes.tf</strong><dd><code>Bump ArgoCD version in Terraform locals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

generate-tenant-readmes.tf

<li>Updated <code>argocd_app_version</code> local variable to v2.14.12<br> <li> Ensures usage of the latest ArgoCD application version


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/387/files#diff-5a957cf85812d174f421400bace74d4e43760af834a5b348ac40f84eb5f6ebec">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>