### PR TITLE
fix: quote the kubernetes version under aws.yaml

### DIFF
--- a/VERSIONS/aws.yaml
+++ b/VERSIONS/aws.yaml
@@ -20,5 +20,5 @@ versions:
     version: 1.30.11-20250610
 
   - name: kubernetes_version
-    version: 1.30
+    version: "1.30"
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Quote kubernetes version string in aws.yaml configuration


___

### **Changes diagram**

```mermaid
flowchart LR
  A["aws.yaml config"] --> B["kubernetes_version: 1.30"] --> C["kubernetes_version: \"1.30\""]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws.yaml</strong><dd><code>Quote kubernetes version string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

VERSIONS/aws.yaml

- Add quotes around kubernetes version value "1.30"


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/395/files#diff-f6d40d94f01cc4362a11be1f3814a53b4a4639fe1feec9d3933c4802e796b989">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>