### PR TITLE
fix: fixed passing local to module

### DIFF
--- a/generate_platform_versions.tf
+++ b/generate_platform_versions.tf
@@ -9,4 +9,5 @@ module "glueops_platform_versions" {
   calico_helm_chart_version = local.calico_helm_chart_version
   tigera_operator_version   = local.tigera_operator_version
   calico_ctl_version        = local.calico_ctl_version
+  terraform_module_version  = local.terraform_module_version
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add missing `terraform_module_version` parameter to platform versions module


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Local Variable"] -- "Pass to" --> B["Platform Versions Module"]
  B --> C["terraform_module_version Parameter"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_platform_versions.tf</strong><dd><code>Add missing terraform_module_version parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

generate_platform_versions.tf

<li>Add <code>terraform_module_version</code> parameter to module call<br> <li> Pass <code>local.terraform_module_version</code> to platform versions module


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/397/files#diff-e3704ec9e08e530c406447ac732e88dea851064b13dc98f319ca365dde670279">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>