### PR TITLE
fix: add quote to kubernetes_version_placeholder

### DIFF
--- a/modules/kubernetes-versions/0.1.0/version.tpl
+++ b/modules/kubernetes-versions/0.1.0/version.tpl
@@ -12,4 +12,4 @@ versions:
     version: ami_release_version_placeholder
 
   - name: kubernetes_version
-    version: kubernetes_version_placeholder
+    version: "kubernetes_version_placeholder"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add missing quotes to `kubernetes_version_placeholder` in template file


___

### **Changes diagram**

```mermaid
flowchart LR
  A["version.tpl template"] --> B["Add quotes to kubernetes_version_placeholder"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>version.tpl</strong><dd><code>Add quotes to kubernetes version placeholder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/kubernetes-versions/0.1.0/version.tpl

<li>Add double quotes around <code>kubernetes_version_placeholder</code> value<br> <li> Ensure consistency with YAML string formatting


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/399/files#diff-f46de19e69a28a1d0c5c217335df8221a9b1ca314d0fe3ad09a236da54b1bcdc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>