### PR TITLE
chore: bump terraform module version to "v0.36.0"

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -127,7 +127,7 @@ locals {
   calico_helm_chart_version = "v3.29.3"
   calico_ctl_version        = "v3.29.3"
   tigera_operator_version   = "v1.36.7"
-  terraform_module_version  = "v0.35.0"
+  terraform_module_version  = "v0.36.0"
 }
 
 


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Bump terraform module version from v0.35.0 to v0.36.0


___

### **Changes diagram**

```mermaid
flowchart LR
  A["terraform_module_version"] --> B["v0.35.0"] 
  B --> C["v0.36.0"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Bump terraform module version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

- Updated `terraform_module_version` from "v0.35.0" to "v0.36.0"


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/402/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>