### PR TITLE
chore: bump deps versions

### DIFF
--- a/VERSIONS/aws.yaml
+++ b/VERSIONS/aws.yaml
@@ -1,22 +1,21 @@
 versions:
   - name: csi_driver_version
     # kubernetesVersion and addonName provided
-    # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"aws-ebs-csi-driver"}
+    # renovate: eksAddonsFilter={"kubernetesVersion":"1.32","addonName":"aws-ebs-csi-driver"}
     version: v1.48.0-eksbuild.2
 
   - name: coredns_version
     # kubernetesVersion and addonName provided
-    # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"coredns"}
+    # renovate: eksAddonsFilter={"kubernetesVersion":"1.32","addonName":"coredns"}
     version: v1.11.4-eksbuild.22
   
   - name: kube_proxy_version
     # kubernetesVersion and addonName provided
-    # renovate: eksAddonsFilter={"kubernetesVersion":"1.31","addonName":"kube-proxy"}
-    version: v1.31.10-eksbuild.8
+    # renovate: eksAddonsFilter={"kubernetesVersion":"1.32","addonName":"kube-proxy"}
+    version: v1.32.6-eksbuild.8
 
   - name: ami_release_version
-    version: 1.31.7-20250620
+    version: 1.32.7-20250829
 
   - name: kubernetes_version
-    version: "1.31"
-
+    version: "1.32"

--- a/variables.tf
+++ b/variables.tf
@@ -121,15 +121,15 @@ locals {
 }
 
 locals {
-  argocd_app_version        = "v2.14.15"
-  codespace_version         = "v0.97.2"
+  argocd_app_version        = "v2.14.17"
+  codespace_version         = "v0.105.1"
   argocd_helm_chart_version = "7.9.1"
-  glueops_platform_version  = "v0.60.7" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.61.0" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.28.0"
-  calico_helm_chart_version = "v3.29.3"
-  calico_ctl_version        = "v3.29.3"
-  tigera_operator_version   = "v1.36.7"
-  terraform_module_version  = "v0.36.1"
+  calico_helm_chart_version = "v3.29.5"
+  calico_ctl_version        = "v3.29.5"
+  tigera_operator_version   = "v1.36.12"
+  terraform_module_version  = "v0.37.0"
 }
 
 


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Update Kubernetes version from 1.31 to 1.32

- Bump AWS EKS addon versions for new Kubernetes

- Update ArgoCD, Codespace, and platform component versions

- Upgrade Calico networking components to latest versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  K8S["Kubernetes 1.31"] -- "upgrade" --> K8S32["Kubernetes 1.32"]
  K8S32 --> EKS["EKS Addons Update"]
  K8S32 --> APPS["Application Versions"]
  EKS --> CSI["CSI Driver v1.48.0"]
  EKS --> PROXY["Kube-proxy v1.32.6"]
  APPS --> ARGO["ArgoCD v2.14.17"]
  APPS --> CALICO["Calico v3.29.5"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws.yaml</strong><dd><code>Kubernetes and EKS addon version updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

VERSIONS/aws.yaml

<ul><li>Update Kubernetes version from 1.31 to 1.32<br> <li> Bump kube-proxy version to v1.32.6-eksbuild.8<br> <li> Update AMI release version to 1.32.7-20250829<br> <li> Update renovate filters for Kubernetes 1.32 compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/450/files#diff-f6d40d94f01cc4362a11be1f3814a53b4a4639fe1feec9d3933c4802e796b989">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Application and platform component version bumps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<ul><li>Update ArgoCD version from v2.14.15 to v2.14.17<br> <li> Bump Codespace version from v0.97.2 to v0.105.1<br> <li> Update GlueOps platform version to v0.61.0<br> <li> Upgrade Calico components to v3.29.5 and Tigera operator to v1.36.12<br> <li> Update Terraform module version to v0.37.0</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/450/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

