### PR TITLE
chore: Update glueops_platform_version to v0.62.1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -124,7 +124,7 @@ locals {
   argocd_app_version        = "v2.14.20"
   codespace_version         = "v0.109.0"
   argocd_helm_chart_version = "7.9.1"
-  glueops_platform_version  = "v0.62.0" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.62.1" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.29.0"
   calico_helm_chart_version = "v3.29.5"
   calico_ctl_version        = "v3.29.5"


### PR DESCRIPTION
### **User description**
Updated glueops_platform_version to v0.62.1.


___

### **PR Type**
Other


___

### **Description**
- Update `glueops_platform_version` from v0.62.0 to v0.62.1


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Bump glueops platform version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

- Updated `glueops_platform_version` from v0.62.0 to v0.62.1


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/465/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

