### PR TITLE
fix: Downgrade kube_proxy_version to v1.32.6-eksbuild.12

### DIFF
--- a/VERSIONS/aws.yaml
+++ b/VERSIONS/aws.yaml
@@ -12,7 +12,7 @@ versions:
   - name: kube_proxy_version
     # kubernetesVersion and addonName provided
     # renovate: eksAddonsFilter={"kubernetesVersion":"1.32","addonName":"kube-proxy"}
-    version: v1.32.6-eksbuild.13
+    version: v1.32.6-eksbuild.12
 
   - name: ami_release_version
     version: 1.32.9-20251016


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Downgrade kube_proxy_version from v1.32.6-eksbuild.13 to v1.32.6-eksbuild.12

- Addresses compatibility or stability issue with newer kube-proxy build


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["kube_proxy_version<br/>v1.32.6-eksbuild.13"]
  new["kube_proxy_version<br/>v1.32.6-eksbuild.12"]
  old -- "downgrade" --> new
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws.yaml</strong><dd><code>Downgrade kube-proxy version build number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

VERSIONS/aws.yaml

<ul><li>Downgraded <code>kube_proxy_version</code> from v1.32.6-eksbuild.13 to <br>v1.32.6-eksbuild.12<br> <li> Single line change in the version configuration file</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/478/files#diff-f6d40d94f01cc4362a11be1f3814a53b4a4639fe1feec9d3933c4802e796b989">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

