### PR TITLE
chore: Bump glueops_platform_version to v0.64.1

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -124,7 +124,7 @@ locals {
   argocd_app_version        = "v2.14.20"
   codespace_version         = "v0.111.0"
   argocd_helm_chart_version = "7.9.1"
-  glueops_platform_version  = "v0.64.0" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  glueops_platform_version  = "v0.64.1" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.29.0"
   calico_helm_chart_version = "v3.29.5"
   calico_ctl_version        = "v3.29.5"


### PR DESCRIPTION
### **User description**
Updated glueops_platform_version to v0.64.1.


___

### **PR Type**
Enhancement


___

### **Description**
- Bump `glueops_platform_version` from v0.64.0 to v0.64.1

- Updates platform dependency version in Terraform configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["glueops_platform_version: v0.64.0"] -- "version bump" --> new["glueops_platform_version: v0.64.1"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Update glueops platform version variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<ul><li>Updated <code>glueops_platform_version</code> local variable from v0.64.0 to <br>v0.64.1<br> <li> Maintains existing comment referencing <br>module.glueops_platform_helm_values</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/485/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

