### PR TITLE
chore: bump codespace and aws(ami , ebs) versions

### DIFF
--- a/VERSIONS/aws.yaml
+++ b/VERSIONS/aws.yaml
@@ -2,7 +2,7 @@ versions:
   - name: csi_driver_version
     # kubernetesVersion and addonName provided
     # renovate: eksAddonsFilter={"kubernetesVersion":"1.32","addonName":"aws-ebs-csi-driver"}
-    version: v1.51.1-eksbuild.1
+    version: v1.52.1-eksbuild.1
 
   - name: coredns_version
     # kubernetesVersion and addonName provided
@@ -15,7 +15,7 @@ versions:
     version: v1.32.6-eksbuild.12
 
   - name: ami_release_version
-    version: 1.32.9-20251016
+    version: 1.32.9-20251108
 
   - name: kubernetes_version
     version: "1.32"

--- a/variables.tf
+++ b/variables.tf
@@ -122,14 +122,14 @@ locals {
 
 locals {
   argocd_app_version        = "v3.0.20"
-  codespace_version         = "v0.111.0"
+  codespace_version         = "v0.112.0"
   argocd_helm_chart_version = "8.2.7"
   glueops_platform_version  = "v0.64.1" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
   tools_version             = "v0.29.0"
   calico_helm_chart_version = "v3.30.4"
   calico_ctl_version        = "v3.30.4"
   tigera_operator_version   = "v1.38.7"
-  terraform_module_version  = "v0.41.0"
+  terraform_module_version  = "v0.42.1"
 }
 
 variable "opsgenie_emails" {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Bump AWS EBS CSI driver version from v1.51.1 to v1.52.1

- Update AWS AMI release version to latest build date

- Upgrade codespace version from v0.111.0 to v0.112.0

- Bump terraform module version from v0.41.0 to v0.42.1


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Version Updates"] --> B["AWS EBS CSI Driver<br/>v1.51.1 → v1.52.1"]
  A --> C["AWS AMI Release<br/>20251016 → 20251108"]
  A --> D["Codespace<br/>v0.111.0 → v0.112.0"]
  A --> E["Terraform Module<br/>v0.41.0 → v0.42.1"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws.yaml</strong><dd><code>AWS addon and AMI versions updated</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

VERSIONS/aws.yaml

<ul><li>Updated AWS EBS CSI driver version from v1.51.1-eksbuild.1 to <br>v1.52.1-eksbuild.1<br> <li> Updated AMI release version from 1.32.9-20251016 to 1.32.9-20251108 <br>with newer build date</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/489/files#diff-f6d40d94f01cc4362a11be1f3814a53b4a4639fe1feec9d3933c4802e796b989">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Codespace and terraform module versions bumped</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<ul><li>Upgraded codespace version from v0.111.0 to v0.112.0<br> <li> Bumped terraform module version from v0.41.0 to v0.42.1</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/489/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).