### PR TITLE
fix: Update AMI release version in aws.yaml

### DIFF
--- a/VERSIONS/aws.yaml
+++ b/VERSIONS/aws.yaml
@@ -15,7 +15,7 @@ versions:
     version: v1.32.9-eksbuild.2
 
   - name: ami_release_version
-    version: 1.32.9-20251108
+    version: 1.32.9-20251120
 
   - name: kubernetes_version
     version: "1.32"


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **PR Type**
Enhancement


___

### **Description**
- Update AMI release version from 1.32.9-20251108 to 1.32.9-20251120

- Aligns with latest AWS EKS AMI build for Kubernetes 1.32


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oldAMI["AMI version 1.32.9-20251108"] -- "update to latest" --> newAMI["AMI version 1.32.9-20251120"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws.yaml</strong><dd><code>Update AMI release version to latest build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

VERSIONS/aws.yaml

<ul><li>Updated <code>ami_release_version</code> from <code>1.32.9-20251108</code> to <code>1.32.9-20251120</code><br> <li> Reflects the latest AWS EKS AMI build for Kubernetes 1.32</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites/pull/498/files#diff-f6d40d94f01cc4362a11be1f3814a53b4a4639fe1feec9d3933c4802e796b989">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).