### PR TITLE
ci: make terraform-docs a check instead of auto-committing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,18 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 
-    - name: Render terraform docs and push changes back to PR
+    # Verify the injected terraform-docs block in README.md is current, but do
+    # NOT push a commit back to the PR branch. Auto-pushing a
+    # "docs: automated update of terraform docs" commit caused that message to
+    # win the squash-merge on single-/empty-commit PRs, so release-please saw a
+    # `docs:` subject instead of the real `feat:`/`fix:` and misclassified (or
+    # dropped) the change. This runs as a required check instead: regenerate
+    # docs locally (`terraform-docs`) and commit them if this fails.
+    - name: Check terraform docs are up to date
       uses: terraform-docs/gh-actions@main
       with:
         working-dir: .
         output-file: README.md
         output-method: inject
-        git-push: "true"
-        git-commit-message: "docs: automated update of terraform docs"
+        git-push: "false"
+        fail-on-diff: "true"


### PR DESCRIPTION
## Problem
`docs.yml` pushes a `docs: automated update of terraform docs` commit onto every PR branch (`git-push: true`). With the repo's squash setting (`COMMIT_OR_PR_TITLE`), that bot message becomes the squash-commit **subject** on single-/empty-commit PRs. release-please classifies by the subject that lands on `main`, so the change gets filed under **Documentation** — or dropped — instead of reading the real `feat:`/`fix:`. (This is exactly what happened to the "adding gatekeeper" feat: it landed on `main` as `docs: automated update of terraform docs`.)

## Change
Run terraform-docs as a **check** instead of an auto-committer:
- `git-push: "false"` — no more bot commits on PR branches
- `fail-on-diff: "true"` — the check fails if `README.md`'s injected docs block is stale

## Effect
- Commit subjects on `main` come only from the real PR commits → release-please classifies correctly.
- No stray `docs: automated update` entries polluting the changelog.
- **Contributor workflow change:** if this check fails, run `terraform-docs` locally and commit the updated `README.md` (instead of the bot doing it for you).

## Alternative (no workflow change)
A repo admin can instead set **Settings → General → Pull Requests → squash merge commit title = "Pull request title"** (`squash_merge_commit_title=PR_TITLE`). That makes the squash subject always the (conventional) PR title, keeps auto-docs, and adds no contributor friction. If you prefer that, close this PR. I couldn't apply it myself (needs repo admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)