### PR TITLE
feat: add kube_prometheus_stack_version to generated VERSIONS/glueops.yaml

### DIFF
--- a/generate_platform_versions.tf
+++ b/generate_platform_versions.tf
@@ -2,12 +2,13 @@ module "glueops_platform_versions" {
   source   = "./modules/platform-chart-version/0.1.0"
   for_each = local.environment_map
 
-  argocd_helm_chart_version = local.argocd_helm_chart_version
-  argocd_app_version        = local.argocd_app_version
-  glueops_platform_version  = local.glueops_platform_version
-  codespace_version         = local.codespace_version
-  calico_helm_chart_version = local.calico_helm_chart_version
-  tigera_operator_version   = local.tigera_operator_version
-  calico_ctl_version        = local.calico_ctl_version
-  terraform_module_version  = local.terraform_module_version
+  argocd_helm_chart_version     = local.argocd_helm_chart_version
+  argocd_app_version            = local.argocd_app_version
+  glueops_platform_version      = local.glueops_platform_version
+  codespace_version             = local.codespace_version
+  calico_helm_chart_version     = local.calico_helm_chart_version
+  tigera_operator_version       = local.tigera_operator_version
+  calico_ctl_version            = local.calico_ctl_version
+  terraform_module_version      = local.terraform_module_version
+  kube_prometheus_stack_version = local.kube_prometheus_stack_version
 }

--- a/modules/platform-chart-version/0.1.0/main.tf
+++ b/modules/platform-chart-version/0.1.0/main.tf
@@ -41,6 +41,12 @@ variable "codespace_version" {
   nullable    = false
 }
 
+variable "kube_prometheus_stack_version" {
+  description = "kube-prometheus-stack helm chart version (used to install its CRDs)"
+  type        = string
+  nullable    = false
+}
+
 variable "terraform_module_version" {
   description = "terraform-module-cloud-aws-kubernetes-cluster version"
   type        = string
@@ -52,7 +58,7 @@ data "local_file" "version" {
 }
 
 output "platform_versions" {
-  value = replace(replace(replace(replace(replace(replace(replace(replace(
+  value = replace(replace(replace(replace(replace(replace(replace(replace(replace(
     data.local_file.version.content,
     "glueops_platform_helm_chart_version_placeholder", "${var.glueops_platform_version}"),
     "argocd_helm_chart_version_placeholder", "${var.argocd_helm_chart_version}"),
@@ -61,5 +67,6 @@ output "platform_versions" {
     "calico_helm_chart_version_placeholder", "${var.calico_helm_chart_version}"),
     "calico_ctl_version_placeholder", "${var.calico_ctl_version}"),
     "terraform_module_version_placeholder", "${var.terraform_module_version}"),
-  "tigera_operator_version_placeholder", "${var.tigera_operator_version}")
+    "tigera_operator_version_placeholder", "${var.tigera_operator_version}"),
+  "kube_prometheus_stack_version_placeholder", "${var.kube_prometheus_stack_version}")
 }

--- a/modules/platform-chart-version/0.1.0/version.tpl
+++ b/modules/platform-chart-version/0.1.0/version.tpl
@@ -15,3 +15,5 @@ versions:
     version: tigera_operator_version_placeholder
   - name: terraform_module_version
     version: terraform_module_version_placeholder
+  - name: kube_prometheus_stack_version
+    version: kube_prometheus_stack_version_placeholder

--- a/modules/tenant-readme/0.1.0/tenant-readme.md.tpl
+++ b/modules/tenant-readme/0.1.0/tenant-readme.md.tpl
@@ -31,21 +31,34 @@ gh repo clone placeholder_github_owner/placeholder_repo_name
 ## Deploying GlueOps the Platform
 
 1. Deploy ArgoCD
-    * From the root of this repository run `captain_utils`, then select `production` -> `argocd`. It installs the ArgoCD CRDs, the kube-prometheus-stack CRDs, and the ArgoCD Helm Chart using the versions pinned in `VERSIONS/glueops.yaml`.
+    * From the root of this repository run:
 
     ```sh
     captain_utils
     ```
 
-    * Ensure all services are available and running before proceeding to the next step (`captain_utils` -> `inspect_pods`, or `watch kubectl get pods -n glueops-core`)
+    * Then step through the menus:
+        1. Select `production`
+        2. Select `argocd`
+        3. Select the ArgoCD helm chart version (pinned by `VERSIONS/glueops.yaml`)
+        4. Select the ArgoCD App Version (pinned by `VERSIONS/glueops.yaml`)
+        5. Review the diff shown in the pager, then press `q` to exit it
+        6. Confirm `Apply upgrade`. This installs the ArgoCD CRDs, the kube-prometheus-stack CRDs, and the ArgoCD Helm Chart.
+    * Ensure all services are available and running before proceeding to the next step (`captain_utils` -> `production` -> `inspect_pods`, or `watch kubectl get pods -n glueops-core`)
 
 2. Deploy the GlueOps Platform
-    * Run `captain_utils` again, then select `production` -> `glueops-platform`. It shows a diff for confirmation, then installs the GlueOps Platform helm chart using the version pinned in `VERSIONS/glueops.yaml`.
+    * Run `captain_utils` again:
 
     ```sh
     captain_utils
     ```
 
+    * Then step through the menus:
+        1. Select `production`
+        2. Select `glueops-platform`
+        3. Select the GlueOps Platform version (pinned by `VERSIONS/glueops.yaml`)
+        4. Review the diff shown in the pager, then press `q` to exit it
+        5. Confirm `Apply upgrade` to install the GlueOps Platform helm chart
     * Monitor with `watch kubectl get applications -n glueops-core` until all applications are synced and healthy, except `vault`
     * [Configure Vault](https://github.com/GlueOps/terraform-module-kubernetes-hashicorp-vault-configuration)
 3. Access Cluster services

--- a/modules/tenant-readme/0.1.0/tenant-readme.md.tpl
+++ b/modules/tenant-readme/0.1.0/tenant-readme.md.tpl
@@ -31,14 +31,13 @@ gh repo clone placeholder_github_owner/placeholder_repo_name
 ## Deploying GlueOps the Platform
 
 1. Deploy ArgoCD
-    * The below command installs ArgoCD CRDs, ArgoCD Helm Chart, and watches services until they are available
-    
+    * From the root of this repository run `captain_utils`, then select `production` -> `argocd`. It installs the ArgoCD CRDs, the kube-prometheus-stack CRDs, and the ArgoCD Helm Chart using the versions pinned in `VERSIONS/glueops.yaml`.
+
     ```sh
-    source <(curl -s https://raw.githubusercontent.com/GlueOps/development-only-utilities/placeholder_tools_version/tools/glueops-platform/deploy-argocd) && \
-        deploy-argocd -c placeholder_argocd_crd_version -h placeholder_argocd_helm_chart_version
+    captain_utils
     ```
 
-    * Ensure all services are available and running before proceeding to the next step
+    * Ensure all services are available and running before proceeding to the next step (`captain_utils` -> `inspect_pods`, or `watch kubectl get pods -n glueops-core`)
 
 2. Deploy the GlueOps Platform
     * Install the GlueOps platform using

--- a/modules/tenant-readme/0.1.0/tenant-readme.md.tpl
+++ b/modules/tenant-readme/0.1.0/tenant-readme.md.tpl
@@ -40,13 +40,13 @@ gh repo clone placeholder_github_owner/placeholder_repo_name
     * Ensure all services are available and running before proceeding to the next step (`captain_utils` -> `inspect_pods`, or `watch kubectl get pods -n glueops-core`)
 
 2. Deploy the GlueOps Platform
-    * Install the GlueOps platform using
+    * Run `captain_utils` again, then select `production` -> `glueops-platform`. It shows a diff for confirmation, then installs the GlueOps Platform helm chart using the version pinned in `VERSIONS/glueops.yaml`.
 
     ```sh
-    source <(curl -s https://raw.githubusercontent.com/GlueOps/development-only-utilities/placeholder_tools_version/tools/glueops-platform/deploy-glueops-platform) && \
-        deploy-glueops-platform -v placeholder_glueops_platform_version
+    captain_utils
     ```
 
+    * Monitor with `watch kubectl get applications -n glueops-core` until all applications are synced and healthy, except `vault`
     * [Configure Vault](https://github.com/GlueOps/terraform-module-kubernetes-hashicorp-vault-configuration)
 3. Access Cluster services
     * [Cluster Info](https://cluster-info.placeholder_repo_name): https://cluster-info.placeholder_repo_name

--- a/variables.tf
+++ b/variables.tf
@@ -162,17 +162,18 @@ locals {
 }
 
 locals {
-  argocd_app_version        = "v3.2.12"
-  codespace_version         = "v0.145.0"
-  argocd_helm_chart_version = "9.3.7"
-  glueops_platform_version  = "v0.73.1" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
-  tools_version             = "v0.36.0"
-  calico_helm_chart_version = "v3.31.4"
-  calico_ctl_version        = "v3.31.4"
-  tigera_operator_version   = "v1.40.7"
-  terraform_module_version  = "v0.50.0"
-  gatekeeper_tag            = "v0.1.1@sha256:33f96e0ecc628078c00c68722a670fb72693860219219972503df0ee2c6a3ece"
-  
+  argocd_app_version            = "v3.2.12"
+  codespace_version             = "v0.145.0"
+  argocd_helm_chart_version     = "9.3.7"
+  glueops_platform_version      = "v0.73.1" # this also needs to be updated in the module.glueops_platform_helm_values // generate-helm-values.tf
+  tools_version                 = "v0.36.0"
+  calico_helm_chart_version     = "v3.31.4"
+  calico_ctl_version            = "v3.31.4"
+  tigera_operator_version       = "v1.40.7"
+  terraform_module_version      = "v0.50.0"
+  kube_prometheus_stack_version = "59.1.0" # chart version pinned by application-kube-prometheus-stack-crds.yaml in platform-helm-chart-platform
+  gatekeeper_tag                = "v0.1.1@sha256:33f96e0ecc628078c00c68722a670fb72693860219219972503df0ee2c6a3ece"
+
 }
 
 variable "opsgenie_emails" {


### PR DESCRIPTION
## Summary
- Adds a `kube_prometheus_stack_version` entry (pinned to `59.1.0`) to the `VERSIONS/glueops.yaml` generated for each captain cluster repo.

## Why
The captain_utils tooling in GlueOps/codespaces (companion PR incoming) installs the kube-prometheus-stack CRDs via `kubectl apply --server-side` during ArgoCD installs — replacing the `kube-prometheus-stack-crds` ArgoCD Application from platform-helm-chart-platform — and reads the chart version from `VERSIONS/glueops.yaml` like every other component. `59.1.0` matches the `targetRevision` currently pinned in `application-kube-prometheus-stack-crds.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)