### PR TITLE
chore: add gitignore, buddy security profile and shared secret scanner

### DIFF
--- a/.dragon-buddy/README.md
+++ b/.dragon-buddy/README.md
@@ -1,0 +1,42 @@
+# Dragon Dev Buddy profile
+
+`config.json` records what this repo is, how exposed it is, what data it touches
+and which trust boundaries exist. Security tooling reads it instead of asking
+again every run. It is committed so the whole team shares one profile.
+
+`reports/` is gitignored — audit output quotes real findings and real config.
+
+## Why the scanner exists
+
+This module mints IAM secret access keys and takes a GitHub App private key, an
+OAuth client secret and the autoglue org secret as inputs. A committed profile is
+visible to everyone with repo access, so a credential landing in it is a leak.
+
+`scan-config.sh` (git plumbing) and `scan-config.py` (the detector) look for
+credential-shaped values in `.dragon-buddy/*.json`: AWS access key ids, GitHub
+tokens and PATs, PEM private keys, Slack tokens, JWTs, Vault tokens, and opaque
+high-entropy values sitting under a key named like a secret.
+
+```sh
+./.dragon-buddy/scan-config.sh                 # scan staged content (hook mode)
+./.dragon-buddy/scan-config.sh FILE...         # scan files on disk
+```
+
+Exit 0 clean, 1 on a finding, 2 on a usage or environment error.
+
+## Enabling the pre-commit hook
+
+Once per clone:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+`.git/hooks/` is not shared by git, which is why the hook lives in the tracked
+`.githooks/` directory instead. Setting `core.hooksPath` is per-clone config and
+cannot be committed, so each person runs the line above.
+
+Bypass a single commit with `git commit --no-verify`.
+
+CI runs the same scanner on every pull request via
+`.github/workflows/scan-buddy-profile.yml`, so an unenabled hook is not a hole.

--- a/.dragon-buddy/config.json
+++ b/.dragon-buddy/config.json
@@ -1,10 +1,20 @@
 {
-  "_comment": "Dragon Dev Buddy profile. Written by dragon-dev-buddy:buddy-setup. Every skill in the pack reads this instead of re-interviewing you.",
+  "_comment": "Written by dragon-dev-buddy:buddy-setup to .dragon-buddy/config.json. Re-run that skill when the project, stack or threat profile changes. Safe to commit EXCEPT the engagement block if it names a client.",
+  "version": 1,
   "project": {
     "name": "terraform-module-cloud-multy-prerequisites",
     "what_it_is": "Terraform module that stands up per-tenant cloud prerequisites for the GlueOps platform: Route53 parent and per-cluster zones with DNSSEC, S3 backup and Loki log buckets with cross-region replication, scoped IAM users and access keys for platform components, and a generated tenant 'captain' GitHub repo carrying the rendered Helm values.",
+    "repo": "git@github.com:GlueOps/terraform-module-cloud-multy-prerequisites.git",
     "primary_language": "HCL",
-    "stack": "Terraform module, no application runtime. Providers: hashicorp/aws (4 aliases, all assuming OrganizationAccountAccessRole cross-account), cloudflare/cloudflare, hashicorp/random, GlueOps/autoglue 0.10.12. Eight local submodules under modules/*/<semver>/ plus remote GlueOps modules pinned by git tag.",
+    "stack": [
+      "Terraform module, no application runtime",
+      "hashicorp/aws (4 aliases, all assuming OrganizationAccountAccessRole cross-account)",
+      "cloudflare/cloudflare",
+      "hashicorp/random",
+      "GlueOps/autoglue 0.10.12",
+      "8 local submodules under modules/*/<semver>/",
+      "remote GlueOps modules pinned by git tag"
+    ],
     "runtime": "Terraform CLI, run by platform engineers and by the consuming tenant repo",
     "deploy_target": "AWS multi-account (Route53, KMS, S3, IAM), GitHub (tenant repo creation), autoglue SaaS control plane"
   },
@@ -24,21 +34,36 @@
       "Static long-lived IAM access keys with no rotation path, in preference to IRSA/OIDC."
     ]
   },
-  "engagement": {},
+  "engagement": {
+    "_comment": "Only used by skills that produce exploit code or client-facing reports. Leave empty for ordinary internal work on your own code.",
+    "authorized_scope": [],
+    "out_of_scope": [],
+    "authorization_ref": "",
+    "contact": ""
+  },
   "practice": {
     "test_command": null,
+    "lint_command": "terraform fmt -check -recursive",
+    "build_command": "terraform validate",
     "sca_tool": "renovate",
-    "sast_tool": null,
-    "secret_scanner": "github-secret-scanning",
-    "ci": "github-actions (release-please, terraform-docs)"
+    "sast_tool": "none",
+    "secret_scanner": "github-secret-scanning, gitguardian",
+    "ci": "GitHub Actions (release-please, terraform-docs, scan-buddy-profile)"
   },
   "buddy": {
     "enabled": true,
-    "name": "Emberchaos",
-    "mcp_server": "buddy"
+    "server": "buddy",
+    "advise_before_work": true,
+    "observe_after_every_skill": true,
+    "skill_prefix": "dragon-dev-buddy"
   },
   "output": {
-    "reports_dir": ".dragon-buddy/reports"
+    "_comment": "Deliberately not the docs/security default: docs/ is tracked here and README.md is generated from docs/.header.md, so reports would be committed. .dragon-buddy/reports/ is gitignored.",
+    "reports_dir": ".dragon-buddy/reports",
+    "format": "markdown"
   },
-  "skill_level": "advanced"
+  "skill_level": "platform engineer, fluent in Terraform and AWS multi-account",
+  "voice": {
+    "avoid": []
+  }
 }

--- a/.dragon-buddy/config.json
+++ b/.dragon-buddy/config.json
@@ -1,0 +1,44 @@
+{
+  "_comment": "Dragon Dev Buddy profile. Written by dragon-dev-buddy:buddy-setup. Every skill in the pack reads this instead of re-interviewing you.",
+  "project": {
+    "name": "terraform-module-cloud-multy-prerequisites",
+    "what_it_is": "Terraform module that stands up per-tenant cloud prerequisites for the GlueOps platform: Route53 parent and per-cluster zones with DNSSEC, S3 backup and Loki log buckets with cross-region replication, scoped IAM users and access keys for platform components, and a generated tenant 'captain' GitHub repo carrying the rendered Helm values.",
+    "primary_language": "HCL",
+    "stack": "Terraform module, no application runtime. Providers: hashicorp/aws (4 aliases, all assuming OrganizationAccountAccessRole cross-account), cloudflare/cloudflare, hashicorp/random, GlueOps/autoglue 0.10.12. Eight local submodules under modules/*/<semver>/ plus remote GlueOps modules pinned by git tag.",
+    "runtime": "Terraform CLI, run by platform engineers and by the consuming tenant repo",
+    "deploy_target": "AWS multi-account (Route53, KMS, S3, IAM), GitHub (tenant repo creation), autoglue SaaS control plane"
+  },
+  "security": {
+    "exposure": "public",
+    "data_sensitivity": "credentials",
+    "compliance": [],
+    "auth_model": "AWS cross-account STS assume-role into OrganizationAccountAccessRole; long-lived IAM users with static access keys minted for in-cluster workloads (cert-manager, external-dns, loki, vault init/backup, tls-cert backup/restore, route53-autoglue); GitHub App and OAuth App credentials passed in as module inputs.",
+    "trust_boundaries": [
+      "Management DNS account -> tenant account: NS and DS delegation records are written into a hosted zone in a different AWS account via assume-role.",
+      "Terraform state -> everywhere: IAM secret access keys minted here land in state and are rendered into the tenant captain repo's Helm values.",
+      "Platform -> autoglue/waggle SaaS: provider configured with an org key and org secret against an external base_url outside the AWS trust domain.",
+      "Public internet -> cluster ingress: wildcard *.apps.<cluster>.<tenant> CNAME published in a public Route53 zone."
+    ],
+    "known_risk_areas": [
+      "Secret-bearing input variables are not marked sensitive = true in variables.tf (autoglue_org_secret, github_oauth_app_client_secret, github_tenant_app_b64enc_private_key, waggle_api_key), so they can surface in plan output and CI logs.",
+      "Static long-lived IAM access keys with no rotation path, in preference to IRSA/OIDC."
+    ]
+  },
+  "engagement": {},
+  "practice": {
+    "test_command": null,
+    "sca_tool": "renovate",
+    "sast_tool": null,
+    "secret_scanner": "github-secret-scanning",
+    "ci": "github-actions (release-please, terraform-docs)"
+  },
+  "buddy": {
+    "enabled": true,
+    "name": "Emberchaos",
+    "mcp_server": "buddy"
+  },
+  "output": {
+    "reports_dir": ".dragon-buddy/reports"
+  },
+  "skill_level": "advanced"
+}

--- a/.dragon-buddy/scan-config.py
+++ b/.dragon-buddy/scan-config.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Detect credential-shaped values in a buddy profile. Reads JSON on stdin.
+
+Usage: scan-config.py LABEL  <  content.json
+Exit 0 clean, 1 on a finding or invalid JSON.
+"""
+import json
+import re
+import sys
+
+PATTERNS = [
+    (re.compile(r"\b(?:AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}\b"), "AWS access key id"),
+    (re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b"), "GitHub token"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{22,}\b"), "GitHub fine-grained PAT"),
+    (re.compile(r"-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----"), "PEM private key"),
+    (re.compile(r"\bxox[abposr]-[A-Za-z0-9-]{10,}\b"), "Slack token"),
+    (re.compile(r"\bsk-[A-Za-z0-9]{32,}\b"), "API secret key"),
+    (re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"), "JWT"),
+    (re.compile(r"\bhvs\.[A-Za-z0-9_-]{20,}\b"), "Vault token"),
+]
+
+# Key names whose value should never be a literal credential.
+SECRET_KEY = re.compile(
+    r"(secret|token|password|passwd|credential|private_key|api_key|access_key|_key$|^key$)",
+    re.I,
+)
+# Credential-shaped: no whitespace and long. Prose and identifiers are excluded below.
+OPAQUE = re.compile(r"^[A-Za-z0-9+/=_.:-]{20,}$")
+# Ordinary lowercase identifiers and paths: renovate, github-secret-scanning, .dragon-buddy/reports
+IDENTIFIER = re.compile(r"^[a-z0-9]+(?:[-_./][a-z0-9]+)*$")
+
+
+def walk(node, path, findings):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            walk(v, f"{path}.{k}" if path else k, findings)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            walk(v, f"{path}[{i}]", findings)
+    elif isinstance(node, str):
+        for pat, what in PATTERNS:
+            if pat.search(node):
+                findings.append((path or "<root>", what))
+                return
+        leaf = path.split(".")[-1].split("[")[0]
+        if SECRET_KEY.search(leaf) and OPAQUE.match(node) and not IDENTIFIER.match(node):
+            findings.append((path, "credential-shaped value under a secret-named key"))
+
+
+def main():
+    label = sys.argv[1] if len(sys.argv) > 1 else "<stdin>"
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(f"  {label}: empty document, nothing scanned", file=sys.stderr)
+        return 1
+
+    try:
+        doc = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"  {label}: invalid JSON ({e})", file=sys.stderr)
+        return 1
+
+    findings = []
+    walk(doc, "", findings)
+
+    # Catch secrets sitting inside prose values, not just under secret-named keys.
+    seen = {what for _, what in findings}
+    for pat, what in PATTERNS:
+        if what not in seen and pat.search(raw):
+            findings.append(("<document>", what))
+
+    for path, what in findings:
+        print(f"  {label}: {what} at {path}", file=sys.stderr)
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.dragon-buddy/scan-config.sh
+++ b/.dragon-buddy/scan-config.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Block credential-shaped values from being committed in .dragon-buddy/*.json.
+#
+# The buddy profile holds prose: what the project is, how exposed it is, which
+# trust boundaries exist. It is committed so the team shares one profile. If a
+# real credential ever lands in it, this stops the commit.
+#
+#   ./.dragon-buddy/scan-config.sh              scan staged content (pre-commit)
+#   ./.dragon-buddy/scan-config.sh FILE...      scan files on disk
+#
+# Exit 0 clean, 1 on a finding, 2 on a usage or environment error.
+
+set -uo pipefail
+
+here=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+detector="$here/scan-config.py"
+
+command -v python3 >/dev/null 2>&1 || {
+  echo "scan-config: python3 not found, cannot scan" >&2
+  exit 2
+}
+[ -f "$detector" ] || {
+  echo "scan-config: detector missing at $detector" >&2
+  exit 2
+}
+
+rc=0
+
+if [ "$#" -gt 0 ]; then
+  for f in "$@"; do
+    [ -f "$f" ] || { echo "scan-config: no such file: $f" >&2; exit 2; }
+    python3 "$detector" "$f" <"$f" || rc=1
+  done
+else
+  # Pre-commit mode: scan the staged blob, not the working tree.
+  staged=$(git diff --cached --name-only --diff-filter=ACM -- '.dragon-buddy/*.json')
+  [ -n "$staged" ] || exit 0
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    git show ":$f" | python3 "$detector" "$f" || rc=1
+  done <<<"$staged"
+fi
+
+if [ "$rc" -ne 0 ]; then
+  cat >&2 <<'MSG'
+
+scan-config: refusing the commit — the buddy profile holds prose, not credentials.
+Remove the value, then either re-stage or add .dragon-buddy/config.json to .gitignore.
+Override once with: git commit --no-verify
+MSG
+fi
+
+exit "$rc"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Tracked git hook. Enable once per clone with:
+#
+#   git config core.hooksPath .githooks
+#
+# Blocks a commit that would put a credential-shaped value into the
+# dragon-dev-buddy profile, which is committed and therefore public to
+# everyone with repo access.
+
+set -euo pipefail
+
+exec "$(git rev-parse --show-toplevel)/.dragon-buddy/scan-config.sh"

--- a/.github/workflows/scan-buddy-profile.yml
+++ b/.github/workflows/scan-buddy-profile.yml
@@ -1,0 +1,29 @@
+name: Scan buddy profile
+
+# The dragon-dev-buddy profile is committed so the team shares one security
+# profile. It is meant to hold prose, never credentials. The pre-commit hook in
+# .githooks/ catches this locally, but only for people who enabled it — this job
+# is the backstop that runs for everyone.
+
+on:
+  - pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Scan .dragon-buddy JSON for credential-shaped values
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(.dragon-buddy/*.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No buddy profile JSON present, nothing to scan."
+            exit 0
+          fi
+          ./.dragon-buddy/scan-config.sh "${files[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Terraform working directories and provider cache
+**/.terraform/*
+.terraform.tfstate.lock.info
+
+# State files — these carry the IAM secret access keys this module mints
+*.tfstate
+*.tfstate.*
+
+# Plan output — a saved plan contains the same secrets as state
+*.tfplan
+*.tfplan.*
+
+# Variable files — these carry the GitHub App private key, OAuth client secret
+# and autoglue org secret this module takes as input
+*.tfvars
+*.tfvars.json
+
+# Crash logs
+crash.log
+crash.*.log
+
+# Terraform CLI config, which may hold registry credentials
+.terraformrc
+terraform.rc
+
+# Dragon Dev Buddy: the profile in config.json is shared, audit reports are not
+.dragon-buddy/reports/


### PR DESCRIPTION
## What

Three things, in dependency order.

**1. A `.gitignore`, which this repo did not have at all.**

This module mints IAM secret access keys and takes a GitHub App private key, an OAuth client secret and the autoglue org secret as inputs. Without a `.gitignore`, a stray `*.tfstate`, `*.tfplan` or `*.tfvars` commits live credentials. Now covered, along with Terraform working directories, crash logs and CLI config.

Verified no currently-tracked file becomes ignored — `.terraform-docs.yml` was the near-miss, and `**/.terraform/*` does not match it.

**2. A committed dragon-dev-buddy profile at `.dragon-buddy/config.json`.**

Records exposure (`public` — the module publishes Route53 zones and a `*.apps` wildcard pointing at cluster ingress), data sensitivity (`credentials`), the four real trust boundaries, and known risk areas. Security tooling reads this instead of re-deriving it each run. Tracked so the team shares one profile; `reports/` is ignored because audit output quotes real findings.

**3. A secret scanner guarding that decision.**

A committed profile is readable by everyone with repo access, so a credential landing in it is a leak. `.dragon-buddy/scan-config.py` detects AWS access key ids, GitHub tokens and PATs, PEM private keys, Slack tokens, JWTs, Vault tokens, and opaque high-entropy values under secret-named keys. `.dragon-buddy/scan-config.sh` wraps it for both staged (hook) and file modes.

It is enforced twice, because either alone has a hole:

- `.githooks/pre-commit`, tracked, enabled per clone with `git config core.hooksPath .githooks`. Fast local feedback, but `core.hooksPath` is local config and cannot be committed, so it can go unenabled.
- `.github/workflows/scan-buddy-profile.yml`, running the same scanner on every PR. Covers everyone regardless.

## Testing

Scanner unit-tested against six inputs: clean config passes; AWS key, GitHub token, PEM-in-prose, opaque-value-under-`api_key`, and empty-document all reject. Then end-to-end through the real hook via `core.hooksPath` — a commit carrying a seeded `ghp_` token was refused and no commit object was created. CI step dry-run under bash; workflow YAML parses.

Worth noting the first version of the scanner was broken in a way that passed everything: a heredoc occupied python's stdin, so it read an empty document and exited clean. That is why the empty-document case is now an explicit failure rather than a silent success.

## Notes for review

- `README.md` is generated wholesale by terraform-docs from `docs/.header.md`, so the setup docs live in `.dragon-buddy/README.md` instead.
- No Terraform changes. No resources added, changed or destroyed.
- After merge, everyone should run `git config core.hooksPath .githooks` once.