### PR TITLE
docs(migration): require latest pre-split release before migrating (review finding M4)

### DIFF
--- a/docs/generate-moved-blocks.sh
+++ b/docs/generate-moved-blocks.sh
@@ -20,9 +20,12 @@
 #
 # The output is chained (hop 1 relocates legacy root-level addresses into the
 # tenant-base/captain-cluster shape, hop 2 splits them out to the new module
-# blocks), and tofu follows the chain — so the plan is clean regardless of
-# which module version the tenant last applied. Verified empirically from
-# both state forms: moves only, 0/0/0.
+# blocks), and tofu follows the chain — so the moves resolve cleanly
+# regardless of which module version the tenant last applied. Verified
+# empirically from both state forms: moves only, 0/0/0. Address-independence
+# does NOT cover generated-file content: a tenant whose last applied release
+# predates the latest pre-split tag also sees in-place changes at the gate —
+# apply that tag first (see docs/migration/MIGRATION.md, Prerequisite).
 #
 # Assumptions:
 #   - the old call is named module "tenant" (set OLD_MODULE_LABEL if the tenant

--- a/docs/migration/MIGRATION.md
+++ b/docs/migration/MIGRATION.md
@@ -1,8 +1,22 @@
 # Migrating a tenant to per-cluster module calls
 
 One PR per tenant, **no state access**: the generated moved blocks are
-chained and no-op wherever they don't apply, so the same PR plans clean
-regardless of which module version the tenant last applied.
+chained and no-op wherever they don't apply, so the same moved blocks
+resolve clean regardless of which module version the tenant last applied.
+That version-independence covers state **addresses** only — generated-file
+*content* is version-dependent, which is why the prerequisite below exists.
+
+## Prerequisite: be on the latest pre-split release first
+
+The gate demands a moves-only plan. The migration PR can only produce one
+if the tenant's last **applied** release is the latest pre-split tag
+(**v0.87.0** at time of writing). A tenant behind that will see in-place
+updates on generated captain-repo files (version-pin drift absorbed into
+the migration plan) — a correctly formed migration, blocked at the gate.
+
+If the tenant is behind: first bump the OLD `module "tenant"` call's
+`?ref=` to the latest pre-split tag, merge/apply that as a normal release
+PR, then start the migration.
 
 ## Conventions (required)
 
@@ -41,8 +55,9 @@ The manual steps below are equivalent:
    bash /tmp/multy/docs/generate-moved-blocks.sh > moved-migration.tf   # run in the tenant repo
    ```
 
-   The output is chained: the same file plans clean regardless of which
-   module version this tenant last applied.
+   The output is chained: the same file's moves resolve clean regardless of
+   which module version this tenant last applied (addresses are
+   version-independent; generated-file content is not — see Prerequisite).
 2. Add `providers.tf` to the tenant repo — the five aliased AWS providers,
    autoglue, and github providers per the template below (everything the
    module stack previously configured internally or read from CI env).
@@ -95,7 +110,10 @@ The manual steps below are equivalent:
    "No changes" plan; the moved lines ARE the migration. Anything else
    (creates, destroys, changes, provider errors) means something is wrong
    (mislabeled cluster block, stale moved file, old module "tenant" call not
-   deleted) — fix before merging.
+   deleted) — fix before merging. In-place **changes on generated
+   captain-repo files** specifically mean the tenant's last apply predates
+   the latest pre-split release: close this PR's plan cycle, apply that
+   release with the OLD tenant.tf first (see Prerequisite), then re-plan.
 6. Merge (auto-applies the state moves). **Post-apply check:** the tenant's
    captain repos received zero new commits (generated files byte-identical).
 7. **Follow-up PR:** delete `moved-migration.tf`. Its plan is the true no-op


### PR DESCRIPTION
Merges into #662. Fixes review finding **M4**: the migration doc claimed plans are clean "regardless of which module version the tenant last applied" — true for state addresses (the chained moved blocks), false for generated-file **content**. A tenant whose last apply predates the split baseline absorbs version-pin drift into its migration plan as in-place changes on generated captain-repo files, and the moves-only gate then blocks a correctly formed migration with no documented remedy — while the deleted root leaves that tenant unable to apply anything else.

## Changes

- **New `Prerequisite` section** in `docs/migration/MIGRATION.md`: the tenant's last *applied* release must be the latest pre-split tag (v0.87.0 at time of writing) before migrating; tenants behind bump the OLD `module "tenant"` call to that tag and apply it as a normal release PR first.
- **Scoped the version-independence claims to addresses only** in the doc intro, the moved-blocks step, and the `generate-moved-blocks.sh` header comment (the empirical both-state-forms verification statement is preserved — it was and remains true for addresses).
- **Added the stale-tenant signature to the gate's failure list**: in-place changes on generated captain-repo files → apply the pre-split tag with the old tenant.tf, then re-plan. Previously the listed causes (mislabeled block, stale moved file, undeleted old call) would misdirect the operator.

Docs/comments only — no module code, no plan impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDYQHT9nRzGBw8FZY4eg3u