### PR TITLE
fix(migration): harden the wave tooling against silent misuse (findings L8–L13, I8, I10, I11)

### DIFF
--- a/docs/generate-migration.sh
+++ b/docs/generate-migration.sh
@@ -5,9 +5,12 @@
 #
 # Usage, in the tenant repo, on a fresh branch, with this repo checked out at
 # the ref the tenant should pin:
-#   bash /path/to/this-repo/docs/generate-migration.sh [vX.Y.Z]
-# With no argument you are prompted for the ref to pin; an empty answer (or a
-# non-interactive run without an argument) defaults to main.
+#   bash /path/to/this-repo/docs/generate-migration.sh vX.Y.Z
+# The ref is required (with a TTY you are prompted if it is omitted). "main"
+# is refused — a floating pin silently defeats per-cluster versioning and the
+# migration gate cannot catch it (set ALLOW_REF_MAIN=1 to override
+# deliberately). The checkout supplying the moved-block inventory must match
+# the pinned ref (set ALLOW_REF_MISMATCH=1 to override deliberately).
 #
 # Finds the legacy module call by SOURCE in any root .tf file (file and
 # module names do not matter): tenant-scoped arguments move
@@ -22,16 +25,34 @@
 # "Plan: 0 to add, 0 to change, 0 to destroy."
 set -euo pipefail
 
-[ $# -le 1 ] || { echo "usage: $0 [ref-to-pin (e.g. v0.85.0)]" >&2; exit 1; }
+[ $# -le 1 ] || { echo "usage: $0 <ref-to-pin (the designated wave tag, e.g. v0.88.0)>" >&2; exit 1; }
 REF="${1:-}"
-if [ -z "$REF" ]; then
-  if [ -t 0 ]; then
-    read -r -p "Module ref to pin (e.g. v0.85.0) [main]: " REF || true
-  fi
-  REF="${REF:-main}"
+if [ -z "$REF" ] && [ -t 0 ]; then
+  read -r -p "Module ref to pin (the designated wave tag, e.g. v0.88.0): " REF || true
+fi
+[ -n "$REF" ] || { echo "a ref to pin is required (the designated wave tag, e.g. v0.88.0)" >&2; exit 1; }
+if [ "$REF" = "main" ] && [ "${ALLOW_REF_MAIN:-}" != "1" ]; then
+  echo "refusing to pin ?ref=main: a floating pin silently defeats per-cluster versioning" >&2
+  echo "and the migration gate cannot catch it. Pass the designated wave tag (e.g. v0.88.0)," >&2
+  echo "or set ALLOW_REF_MAIN=1 to override deliberately." >&2
+  exit 1
 fi
 echo "pinning ref: $REF" >&2
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# the moved-block inventory is derived from THIS checkout, while $REF is what
+# tenants will actually apply — a mismatch generates moves for the wrong
+# module shape. describe works for tag clones (git clone --branch vX.Y.Z);
+# the branch-name fallback covers branch pins (e.g. piloting a PR branch).
+CHECKOUT_AT="$(git -C "$SCRIPT_DIR" describe --tags --exact-match 2> /dev/null \
+  || git -C "$SCRIPT_DIR" rev-parse --abbrev-ref HEAD 2> /dev/null || echo unknown)"
+if [ "$CHECKOUT_AT" != "$REF" ] && [ "${ALLOW_REF_MISMATCH:-}" != "1" ]; then
+  echo "this checkout is at '$CHECKOUT_AT' but the ref being pinned is '$REF' — the moved" >&2
+  echo "blocks would be generated from a different module shape than tenants apply." >&2
+  echo "Re-clone at the pinned ref (git clone --depth 1 --branch $REF …), or set" >&2
+  echo "ALLOW_REF_MISMATCH=1 if you know the two match." >&2
+  exit 1
+fi
 ls ./*.tf > /dev/null 2>&1 || { echo "no .tf files in current directory" >&2; exit 1; }
 
 PYOUT=$(REF="$REF" python3 - <<'PYEOF'
@@ -218,13 +239,17 @@ while j < len(lines):
 
 CARRY = ['tenant_key', 'tenant_account_id', 'management_tenant_dns_zoneid',
          'this_is_development', 'primary_region', 'backup_region', 'github_owner']
+# arguments a legacy call may legitimately omit: the pre-split root and
+# tenant-base share the same default, so omitting stays equivalence-preserving
+OPTIONAL = ['this_is_development']
 SPECIAL = ['source', 'autoglue_credentials', 'cluster_environments',
            'management_tenant_dns_aws_account_id', 'opsgenie_emails']
 unknown = [k for k in attrs if k not in CARRY + SPECIAL]
 if unknown:
     sys.exit(f'unrecognized module "{old_label}" arguments (handle manually): {unknown}')
 missing = [k for k in CARRY + ['autoglue_credentials', 'cluster_environments',
-                               'management_tenant_dns_aws_account_id'] if k not in attrs]
+                               'management_tenant_dns_aws_account_id']
+           if k not in attrs and k not in OPTIONAL]
 if missing:
     sys.exit(f'missing expected arguments: {missing}')
 
@@ -306,9 +331,11 @@ if len(set(names)) != len(names):
     sys.exit(f'duplicate environment_name values: {sorted(n for n in set(names) if names.count(n) > 1)}')
 
 # ------------------------------------------------------- pre-write validation
-# generated labels must not collide with anything that stays in the repo
+# generated labels must not collide with anything that stays in the repo —
+# in the legacy call's file OR any other root .tf file
 gen_labels = ['tenant_base'] + [f'cluster_{n}' for n in names]
-rest_cfg = preamble + postamble
+rest_cfg = preamble + postamble + ''.join(
+    open(f2).read() for f2 in sorted(glob.glob('*.tf')) if f2 != legacy_file)
 for lbl in gen_labels:
     if old_label == lbl or re.search(rf'^module\s+"{re.escape(lbl)}"', rest_cfg, re.M):
         sys.exit(f'a module named "{lbl}" already exists (or is the legacy call label) — resolve the collision first')
@@ -402,7 +429,8 @@ if hoist:
 out += f'module "tenant_base" {{\n  source = "{SRC}//modules/tenant-base?ref={ref}"\n'
 out += '  providers = {\n    aws.clientaccount         = aws.clientaccount\n    aws.management-tenant-dns = aws.management-tenant-dns\n    aws.primaryregion         = aws.primaryregion\n    aws.replicaregion         = aws.replicaregion\n    aws.dnssec-us-east-1      = aws.dnssec-us-east-1\n  }\n'
 for k in CARRY:
-    out += f'  {k} = {attrs[k]}\n'
+    if k in attrs:  # omitted OPTIONAL args keep relying on the shared default
+        out += f'  {k} = {attrs[k]}\n'
 out += f'  autoglue_credentials = {ag_ref}\n'
 out += '  environment_names    = [' + ', '.join(f'"{n}"' for n in names) + ']\n'
 out += '}\n'
@@ -423,8 +451,10 @@ providers = f'''terraform {{
       source = "hashicorp/random"
     }}
     autoglue = {{
-      source  = "registry.terraform.io/GlueOps/autoglue"
-      version = "0.10.12"
+      # no version constraint here on purpose: tenant-base pins the exact
+      # autoglue version, and a duplicate exact pin here would force a
+      # fleet-wide lockstep providers.tf edit on every future bump
+      source = "registry.terraform.io/GlueOps/autoglue"
     }}
     github = {{
       source = "integrations/github"
@@ -487,6 +517,16 @@ provider "autoglue" {{
 
 # --------------------------------------------------------------- write phase
 # (all validation is done — nothing below here should fail on tenant input)
+
+# snapshot which locals are referenced BEFORE the rewrite: only locals the
+# migration itself orphans may be pruned. A local that was already dead in
+# the tenant repo stays untouched — deleting it would widen the migration
+# diff with unrelated changes.
+referenced_before = set()
+for f2 in sorted(glob.glob('*.tf')):
+    for m2 in re.finditer(r'\blocal\.([A-Za-z0-9_-]+)\b', open(f2).read()):
+        referenced_before.add(m2.group(1))
+
 open(legacy_file, 'w').write(out)
 open('providers.tf', 'w').write(providers)
 if 'opsgenie_emails' in attrs:
@@ -497,6 +537,7 @@ if 'opsgenie_emails' in attrs:
 # can orphan another it referenced.
 pruned_any = True
 pruned_names = []
+skipped_dead = set()
 while pruned_any:
     pruned_any = False
     files = sorted(glob.glob('*.tf'))
@@ -509,7 +550,10 @@ while pruned_any:
             attrs_spans, _ = locals_attrs(text, m2.end())
             for name, s_, e_ in attrs_spans:
                 if not re.search(r'\blocal\.' + re.escape(name) + r'\b', everything):
-                    edits.append((s_, e_, name))
+                    if name in referenced_before:
+                        edits.append((s_, e_, name))
+                    else:
+                        skipped_dead.add(name)
         if edits:
             for s_, e_, name in sorted(edits, reverse=True):
                 text = text[:s_] + text[e_:]
@@ -518,6 +562,9 @@ while pruned_any:
             text = re.sub(r'^locals\s*\{[ \t]*\n\s*\}\n', '', text, flags=re.M)
             open(f2, 'w').write(text)
             pruned_any = True
+if skipped_dead:
+    print('note: locals unreferenced but pre-dating the migration (left in place): '
+          + ', '.join(sorted(skipped_dead)), file=sys.stderr)
 
 for f2 in sorted(glob.glob('*.tf')):
     if open(f2).read().strip() == '':

--- a/docs/generate-moved-blocks.sh
+++ b/docs/generate-moved-blocks.sh
@@ -7,6 +7,9 @@
 # Usage, in the tenant repo AFTER rewriting tenant.tf, with this repo checked
 # out at the ref the new tenant_base/cluster_* blocks pin:
 #   bash /path/to/this-repo/docs/generate-moved-blocks.sh > moved-migration.tf
+# The checkout/pin match is enforced: the script aborts when the ?ref= pins in
+# the tenant's .tf files do not match what this checkout is at (set
+# ALLOW_REF_MISMATCH=1 to override deliberately).
 #
 # Environment names are derived from the module "cluster_<env>" labels in
 # the root .tf files (pass them explicitly as arguments to override).
@@ -47,6 +50,26 @@ OLD_LABEL="${OLD_MODULE_LABEL:-tenant}"
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# the moved-block inventory is derived from THIS checkout, while the tenant's
+# new module blocks apply whatever their ?ref= pins name — a mismatch
+# generates moves for the wrong module shape. describe works for tag clones
+# (git clone --branch vX.Y.Z); the branch-name fallback covers branch pins.
+if ls ./*.tf > /dev/null 2>&1 && [ "${ALLOW_REF_MISMATCH:-}" != "1" ]; then
+  checkout_at="$(git -C "$REPO_ROOT" describe --tags --exact-match 2> /dev/null \
+    || git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2> /dev/null || echo unknown)"
+  pinned_refs="$(grep -hoE 'terraform-module-cloud-multy-prerequisites[^"]*[?&]ref=[^"&]+' ./*.tf 2> /dev/null \
+    | sed -E 's/.*[?&]ref=//' | sort -u)"
+  for r in $pinned_refs; do
+    if [ "$r" != "$checkout_at" ]; then
+      echo "tenant .tf files pin ?ref=$r but this checkout is at '$checkout_at' — the moved" >&2
+      echo "blocks would describe a different module shape than tenants apply. Re-clone at" >&2
+      echo "the pinned ref (git clone --depth 1 --branch $r …), or set ALLOW_REF_MISMATCH=1" >&2
+      echo "if you know the two match." >&2
+      exit 1
+    fi
+  done
+fi
+
 # every resource/module name declared in a module dir, skipping heredoc bodies
 # (generated-file templates contain blocks that are text, not declarations)
 inventory() {
@@ -80,9 +103,12 @@ if [ $# -eq 0 ]; then
   envs=$(awk '
     FNR == 1 { pending = "" }
     /^module "cluster_[A-Za-z0-9_-]+"[[:space:]]*\{/ {
-      lbl = $2
-      gsub(/"/, "", lbl)
-      sub(/^cluster_/, "", lbl)
+      # extract the label from the quoted string itself — never from a
+      # whitespace-delimited field, which a brace hugging the closing quote
+      # (module "cluster_x"{) would corrupt into an invalid address
+      lbl = $0
+      sub(/^module "cluster_/, "", lbl)
+      sub(/".*$/, "", lbl)
       pending = lbl
       next
     }

--- a/docs/migration/MIGRATION.md
+++ b/docs/migration/MIGRATION.md
@@ -58,6 +58,11 @@ The manual steps below are equivalent:
    The output is chained: the same file's moves resolve clean regardless of
    which module version this tenant last applied (addresses are
    version-independent; generated-file content is not — see Prerequisite).
+
+   If the legacy call is not named `module "tenant"`, run the script with
+   `OLD_MODULE_LABEL=<that label>` — otherwise every generated `from` address
+   no-ops and the plan shows a full destroy/create instead of moves.
+   (`generate-migration.sh` detects the label automatically.)
 2. Add `providers.tf` to the tenant repo — the five aliased AWS providers,
    autoglue, and github providers per the template below (everything the
    module stack previously configured internally or read from CI env).
@@ -114,6 +119,10 @@ The manual steps below are equivalent:
    captain-repo files** specifically mean the tenant's last apply predates
    the latest pre-split release: close this PR's plan cycle, apply that
    release with the OLD tenant.tf first (see Prerequisite), then re-plan.
+   An in-place **change on the DNSSEC KMS key policy** means the
+   `dnssec-us-east-1` provider is not assuming `OrganizationAccountAccessRole`
+   in the tenant account (the pre-split module hardcoded that role) — fix the
+   provider block per the template below; do not apply the diff.
 6. Merge (auto-applies the state moves). **Post-apply check:** the tenant's
    captain repos received zero new commits (generated files byte-identical).
 7. **Follow-up PR:** delete `moved-migration.tf`. Its plan is the true no-op
@@ -126,7 +135,10 @@ terraform {
   required_providers {
     aws      = { source = "hashicorp/aws" }
     random   = { source = "hashicorp/random" }
-    autoglue = { source = "registry.terraform.io/GlueOps/autoglue", version = "0.10.12" }
+    # no version constraint on autoglue on purpose: tenant-base pins the exact
+    # version, and a duplicate exact pin here would force a fleet-wide lockstep
+    # providers.tf edit on every future autoglue bump
+    autoglue = { source = "registry.terraform.io/GlueOps/autoglue" }
     github   = { source = "integrations/github" }
   }
 }


### PR DESCRIPTION
Merges into #662. **Stacked on #691** (includes its M4 commit — merge #691 first and this shrinks to one commit, or merge this one and #691 closes as contained).

Every fix is wave-scoped: it only helps if it's in the tag tenants run the tooling from.

## generate-migration.sh

- **L8 — the ref is now required, and `main` is refused.** A floating pin silently defeats per-cluster versioning, and the gate cannot catch it right after cutover (main == tag content). `ALLOW_REF_MAIN=1` overrides deliberately. Stale `v0.85.0` examples (a pre-split tag — following them literally fails init confusingly) now say `v0.88.0`.
- **I11 — checkout/ref consistency check.** The moved-block inventory comes from the checkout; the pins come from the argument. A mismatch generates moves for the wrong module shape — now a hard error (`ALLOW_REF_MISMATCH=1` overrides). Tag clones verify via `git describe`; branch pins (e.g. piloting a PR branch) via the branch-name fallback.
- **L9 — `this_is_development` may be omitted** (pre-split root and tenant-base share the default `false`), keeping legitimately-shaped tenants on the one-command path instead of pushing them to the manual one.
- **L10 — label-collision validation scans every root .tf file**, not just the file holding the legacy call, so nothing is written when `cluster_<env>`/`tenant_base` already exists elsewhere.
- **L11 — locals pruning is surgical.** Only locals the migration itself orphans are deleted (referenced before, unreferenced after, fixpoint over chains). Pre-existing dead locals are reported and left alone — migration diffs stay pure moves.
- **I10 — generated providers.tf no longer duplicates tenant-base's exact autoglue pin.** Two exact pins intersect to unsatisfiable on the first future autoglue bump, forcing a fleet-wide lockstep providers.tf edit; tenant-base's own pin is authoritative.

## generate-moved-blocks.sh

- **L12 — labels extracted from the quoted string**, not awk field $2, so valid-HCL `module "cluster_x"{` no longer yields env `x{` and invalid addresses at exit 0.
- **I11 (manual path) — the tenant's own `?ref=` pins are cross-checked against the checkout**, mirroring the generator's check.

## MIGRATION.md

- **L13** — the manual path now documents `OLD_MODULE_LABEL` (previously a differently-named legacy call produced 199 no-op moves and a full destroy/create plan with nothing pointing at the fix).
- **I8** — gate troubleshooting: an in-place DNSSEC KMS key policy diff means the `dnssec-us-east-1` provider isn't assuming `OrganizationAccountAccessRole` like the pre-split module hardcoded — fix the provider, don't apply.
- **I10** — providers template: exact autoglue pin dropped, with the reason inline.

## Testing

Fixture battery (all passing): happy path with 2 envs + omitted `this_is_development` + an orphaned local (pruned) + a pre-existing dead local (kept, reported); no-arg non-TTY; `main` refused; ref/checkout mismatch on both scripts; cross-file label collision (aborts with zero files written); brace-hugging label extraction; both override env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDYQHT9nRzGBw8FZY4eg3u