### PR TITLE
fix(captain-repo): restore vulnerability_alerts — its removal is not no-diff on older providers

### DIFF
--- a/modules/github-captain-repository/0.1.0/captain.tf
+++ b/modules/github-captain-repository/0.1.0/captain.tf
@@ -4,6 +4,14 @@ resource "github_repository" "captain_repo" {
   name       = var.repository_name
   visibility = "private"
   auto_init  = true
+  # Deprecated in github provider >= 6.x in favour of the
+  # github_repository_vulnerability_alerts resource, but it must stay declared:
+  # the attribute only became Optional+Computed late in 6.x, so on the older
+  # versions pinned in tenants' (unpinned, heterogeneous) lockfiles, dropping it
+  # plans as "vulnerability_alerts = true -> null" — an update-in-place on every
+  # captain repo. Swap to the resource only alongside a fleet-wide provider
+  # floor, and never during a migration wave.
+  vulnerability_alerts = true
 }
 
 resource "github_repository_deploy_key" "captain_repo_deploy_key" {


### PR DESCRIPTION
Merges into #662. **Reverts the attribute removal from #693** (finding I6-attr). Caught by @venkatamutyala seeing `vulnerability_alerts = true -> null` in a real plan.

## What went wrong

#693 removed `vulnerability_alerts = true` on the strength of it being **Optional+Computed** — which makes removal a no-diff. That is true, but **only on github provider 6.13.0**, the version a *fresh* init resolves today. The verification checked the version a fresh init resolves; it should have checked the versions **tenants' committed lockfiles actually pin**. Nothing in this repo or the migration template constrains the github provider, so those lockfiles are heterogeneous and many predate the release that made the attribute Computed.

On those versions, the attribute's absence plans as an update-in-place on **every captain repo** — breaking the moves-only gate fleet-wide, exactly during the wave.

## Evidence

Hand-built `github_repository` state (`vulnerability_alerts = true`) + mocked GitHub API, `tofu plan -refresh=false`:

| github provider | Attribute absent from config |
|---|---|
| 5.42.0 | `- vulnerability_alerts = true -> null` → **1 to change** |
| 6.2.3 | `- vulnerability_alerts = true -> null` → **1 to change** |
| 6.13.0 | no diff (Optional+Computed) |

Differential test on 6.2.3 — identical state, config with vs without the line — shows the attribute line is the **only** difference in the plan. Restoring it is the complete fix.

## The change

Restores `vulnerability_alerts = true` with a comment recording why it cannot simply be dropped, so the next person doesn't repeat this.

**Cost:** the deprecation warning returns in plans on newer providers. That is cosmetic; a dirty plan during the wave is not.

## Follow-on

The attribute → `github_repository_vulnerability_alerts` resource swap moves to the post-wave hardening release, where it must ship **alongside a fleet-wide github provider floor** — otherwise it reintroduces this same heterogeneity problem from the other side.

Same lesson as the aws provider ceiling (L7), which was deferred post-wave for exactly this reason: **unpinned fleet + committed lockfiles = any behavior that varies by provider version is unsafe to change during the wave.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDYQHT9nRzGBw8FZY4eg3u