### PR TITLE
feat(migration): support tenants with no cluster environments

### DIFF
--- a/docs/generate-migration.sh
+++ b/docs/generate-migration.sh
@@ -309,10 +309,16 @@ for line in list_body.splitlines(keepends=True):
         cur += line
 if depth != 0 or heredoc:
     sys.exit('cluster_environments: unbalanced environment object')
-if not envs:
+# A genuinely empty list is a valid tenant with no clusters yet (or whose
+# clusters were decommissioned): it migrates to a tenant_base block alone.
+# An empty result from a NON-empty body means the layout was not understood —
+# never treat that as "no clusters", or a tenant that HAS clusters would be
+# rewritten without their module blocks and plan as a mass destroy.
+if not envs and list_body.strip():
     sys.exit('no cluster_environments objects found')
 
-# invariant: every environment object was captured individually
+# invariant: every environment object was captured individually (this also
+# catches a mis-parse that produced zero objects from a body that has some)
 expected = len(re.findall(r'\benvironment_name\s*=', strip_comments(list_body)))
 if expected != len(envs):
     sys.exit(f'cluster_environments: found {expected} environment_name entries but split '
@@ -573,7 +579,12 @@ for f2 in sorted(glob.glob('*.tf')):
 if pruned_names:
     print(f'note: pruned unreferenced locals: {", ".join(sorted(set(pruned_names)))}', file=sys.stderr)
 
-print(f'environments: {", ".join(names)}', file=sys.stderr)
+if names:
+    print(f'environments: {", ".join(names)}', file=sys.stderr)
+else:
+    print('environments: NONE — the legacy call passed cluster_environments = [], so no '
+          'cluster_<env> blocks were written and environment_names is empty. If this tenant '
+          'DOES have clusters, stop: do not commit this.', file=sys.stderr)
 print(old_label + '\t' + legacy_file + '\t' + ' '.join(names))
 PYEOF
 )

--- a/docs/generate-moved-blocks.sh
+++ b/docs/generate-moved-blocks.sh
@@ -118,7 +118,19 @@ if [ $# -eq 0 ]; then
     }
     /^\}/ { pending = "" }
   ' ./*.tf | sort -u)
-  [ -n "$envs" ] || { echo 'no module "cluster_<env>" blocks sourcing //modules/captain-cluster found in root .tf files' >&2; exit 1; }
+  # zero cluster blocks is legitimate ONLY for a tenant with no clusters, which
+  # still has a tenant_base block. Without one we are not looking at a migrated
+  # tenant repo at all (wrong directory, or tenant.tf not rewritten yet).
+  if [ -z "$envs" ]; then
+    if grep -qE '^[[:space:]]*source[[:space:]]*=.*//modules/tenant-base' ./*.tf; then
+      echo 'no cluster blocks found alongside the tenant_base block — treating this as a' >&2
+      echo 'zero-cluster tenant: emitting shared moves only, no per-environment moves.' >&2
+      echo 'If this tenant DOES have clusters, its cluster_<env> blocks are missing — stop.' >&2
+    else
+      echo 'no module "cluster_<env>" blocks sourcing //modules/captain-cluster found in root .tf files' >&2
+      exit 1
+    fi
+  fi
   # shellcheck disable=SC2086
   set -- $envs
 fi

--- a/docs/migration/MIGRATION.md
+++ b/docs/migration/MIGRATION.md
@@ -26,6 +26,19 @@ PR, then start the migration.
    object> ]` (the same object it had inside the old module "tenant" call, verbatim).
 3. The old `module "tenant"` call is deleted entirely in the same PR.
 
+## Tenants with no clusters
+
+A tenant whose legacy call passed `cluster_environments = []` migrates to a
+`tenant_base` block alone: no `cluster_<env>` blocks, `environment_names = []`,
+and moved blocks covering only the shared resources. Both generators handle
+this and say so on stderr.
+
+Read that message: if a tenant that *does* have clusters ever reports "no
+clusters", stop — the converter failed to understand its
+`cluster_environments` layout, and committing the result would plan as a
+destroy of every cluster resource. (The converter refuses outright on every
+unparseable layout it knows of; this is the backstop for one it does not.)
+
 ## Steps
 
 **One-command path:** clone the tenant repo, create a fresh branch, then with


### PR DESCRIPTION
Merges into #662. Fixes the `no cluster_environments objects found` failure hit on `tenant_interview`.

## The case

A tenant whose legacy call passes `cluster_environments = []` is legitimate — no clusters provisioned yet, or all decommissioned — but both generators refused it, so it had to be hand-migrated. It now produces a `tenant_base` block alone: no `cluster_<env>` blocks, `environment_names = []`, and 77 moved blocks with zero per-environment moves.

tenant-base already supported this; I verified the lifecycle map derives empty, the bucket's rule resource is count-gated, and both `environment_names` validations pass on `[]`.

## The risk, and the three guards against it

The dangerous shape is a tenant that **does** have clusters being rewritten without their module blocks — that plans as a destroy of every cluster resource. So "zero clusters" is only ever inferred from evidence, never from absence:

1. An empty result is accepted only from a **genuinely empty list body**. A non-empty body that yields no objects still exits (the original error).
2. The existing `environment_name`-count invariant catches any mis-parse that produced zero objects from a body that has some.
3. `generate-moved-blocks.sh` accepts zero environments only when a **`tenant_base` block is present** — a wrong directory, or a `tenant.tf` that was never rewritten, still errors.

Both generators announce the zero-cluster path on stderr and explicitly tell the operator to stop if the tenant does have clusters. MIGRATION.md gets a short section carrying the same warning.

## Testing

| Case | Result |
|---|---|
| Zero-cluster tenant, end to end | tenant_base only, `environment_names = []`, 77 moved blocks, 0 per-env |
| **Regression:** 2-environment tenant | unchanged — 199 moved blocks, 2 cluster blocks, `["nonprod", "prod"]` |
| `cluster_environments = [local.env]` | still refuses |
| Layout the splitter can't handle | still refuses |
| Directory with neither cluster nor tenant_base blocks | still refuses |

## Note on `tenant_interview` itself

If that repo is scratch rather than a real tenant, the cheaper answer is still to not migrate it at all — pre-split tags remain available indefinitely. This PR is worth merging either way if any **real** tenant can be cluster-less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDYQHT9nRzGBw8FZY4eg3u